### PR TITLE
Support Dolby Vision playback on Xbox (WebView2)

### DIFF
--- a/Jellyfin/App.xaml
+++ b/Jellyfin/App.xaml
@@ -1,13 +1,35 @@
-﻿<Application
+<Application
     x:Class="Jellyfin.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Jellyfin">
+    xmlns:local="using:Jellyfin"
+    xmlns:converter="using:Jellyfin.Converter">
 
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary>
+
+                    <SolidColorBrush x:Key="Color0" Color="#101010" />
+                    <SolidColorBrush x:Key="Color10" Color="#202020" />
+                    <SolidColorBrush x:Key="Color20" Color="#303030" />
+                    <SolidColorBrush x:Key="Color80" Color="#828282" />
+                    <SolidColorBrush x:Key="Color90" Color="#a9a9a9" />
+                    <SolidColorBrush x:Key="Color100" Color="#FFFFFF" />
+                    <SolidColorBrush x:Key="PrimaryColor" Color="#00A4DC" />
+                    <SolidColorBrush x:Key="PrimaryColorHover" Color="#0CB0E8" />
+                    <SolidColorBrush x:Key="SecondaryColor" Color="#756296" />
+                    <SolidColorBrush x:Key="SecondaryColorHover" Color="#756B86" />
+                    <SolidColorBrush x:Key="OverlayColorBG" Color="LightGray" Opacity="0.2" />
+
+                    <FontFamily x:Key="JellyfinFamilyFont">/Fonts/NotoSans-Regular.ttf#Noto Sans</FontFamily>
+
+                </ResourceDictionary>
                 <ResourceDictionary Source="Resources/JellyfinStyleResources.xaml"/>
+                <ResourceDictionary>
+                    <converter:BooleanVisibilityConverter x:Key="BooleanVisibilityConverter" />
+                    <converter:BooleanVisibilityInverseConverter x:Key="BooleanVisibilityInverseConverter" />
+                </ResourceDictionary>
             </ResourceDictionary.MergedDictionaries>
         </ResourceDictionary>
     </Application.Resources>

--- a/Jellyfin/Controls/JellyfinWebView.xaml.cs
+++ b/Jellyfin/Controls/JellyfinWebView.xaml.cs
@@ -146,6 +146,9 @@ public sealed partial class JellyfinWebView : UserControl
         Content = _wView;
         _wView.Focus(FocusState.Programmatic);
 
+        // Set useragent to Xbox and WebView2 since WebView2 only sets these in Sec-CA-UA, which isn't available over HTTP.
+        _wView.CoreWebView2.Settings.UserAgent += " WebView2 " + Utils.AppUtils.GetDeviceFormFactorType().ToString();
+
         _wView.CoreWebView2.Settings.IsGeneralAutofillEnabled = false; // Disable autofill on Xbox as it puts down the virtual keyboard.
         _wView.CoreWebView2.ContainsFullScreenElementChanged += JellyfinWebView_ContainsFullScreenElementChanged;
     }

--- a/Jellyfin/Converter/BooleanVisibilityConverter.cs
+++ b/Jellyfin/Converter/BooleanVisibilityConverter.cs
@@ -1,0 +1,24 @@
+using System;
+using Windows.UI.Xaml.Data;
+
+namespace Jellyfin.Converter;
+
+/// <summary>
+/// Converts a boolean value to a <see cref="Windows.UI.Xaml.Visibility"/> value.
+/// </summary>
+public class BooleanVisibilityConverter : IValueConverter
+{
+    /// <inheritdoc />
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        return value is true
+            ? Windows.UI.Xaml.Visibility.Visible
+            : Windows.UI.Xaml.Visibility.Collapsed;
+    }
+
+    /// <inheritdoc />
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        return value is Windows.UI.Xaml.Visibility.Visible;
+    }
+}

--- a/Jellyfin/Converter/BooleanVisibilityInverseConverter.cs
+++ b/Jellyfin/Converter/BooleanVisibilityInverseConverter.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Windows.UI.Xaml.Data;
+
+namespace Jellyfin.Converter;
+
+/// <summary>
+/// Converts a boolean value to an inverse <see cref="Windows.UI.Xaml.Visibility"/> value.
+/// </summary>
+public class BooleanVisibilityInverseConverter : IValueConverter
+{
+    /// <inheritdoc />
+    public object Convert(object value, Type targetType, object parameter, string language)
+    {
+        return value is true
+            ? Windows.UI.Xaml.Visibility.Collapsed
+            : Windows.UI.Xaml.Visibility.Visible;
+    }
+
+    /// <inheritdoc />
+    public object ConvertBack(object value, Type targetType, object parameter, string language)
+    {
+        return value is Windows.UI.Xaml.Visibility.Collapsed;
+    }
+}

--- a/Jellyfin/Core/FullScreenManager.cs
+++ b/Jellyfin/Core/FullScreenManager.cs
@@ -1,0 +1,187 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading.Tasks;
+using Jellyfin.Core;
+using Jellyfin.Utils;
+using Windows.Data.Json;
+using Windows.Graphics.Display.Core;
+using Windows.UI.ViewManagement;
+
+namespace Jellyfin.Core;
+
+/// <summary>
+/// Responsible for changing the full screen mode to best match the video content.
+/// </summary>
+public sealed class FullScreenManager
+{
+    private async Task SwitchToBestDisplayMode(uint videoWidth, uint videoHeight, double videoFrameRate, HdmiDisplayHdrOption hdmiDisplayHdrOption)
+    {
+        HdmiDisplayMode bestDisplayMode =
+            GetBestDisplayMode(videoWidth, videoHeight, videoFrameRate, hdmiDisplayHdrOption);
+        if (bestDisplayMode != null)
+        {
+            await HdmiDisplayInformation.GetForCurrentView()
+                ?.RequestSetCurrentDisplayModeAsync(bestDisplayMode, hdmiDisplayHdrOption);
+        }
+    }
+
+    private HdmiDisplayHdrOption GetHdmiDisplayHdrOption(string videoRangeType)
+    {
+        HdmiDisplayInformation hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
+        if (hdmiDisplayInformation == null)
+        {
+            return HdmiDisplayHdrOption.None;
+        }
+
+        IReadOnlyList<HdmiDisplayMode> supportedDisplayModes = hdmiDisplayInformation.GetSupportedDisplayModes();
+        bool displaySupportsDoVi = supportedDisplayModes.Any(mode => mode.IsDolbyVisionLowLatencySupported);
+        bool displaySupportsHdr = supportedDisplayModes.Any(mode => mode.IsSmpte2084Supported);
+
+        HdmiDisplayHdrOption hdrOtherwiseSdr =
+            displaySupportsHdr ? HdmiDisplayHdrOption.Eotf2084 : HdmiDisplayHdrOption.None;
+        HdmiDisplayHdrOption doViOtherwiseHdrOtherwiseSdr =
+            displaySupportsDoVi ? HdmiDisplayHdrOption.DolbyVisionLowLatency : hdrOtherwiseSdr;
+
+        switch (videoRangeType)
+        {
+            // Xbox only supports DOVI profile 5
+            case "DOVI":
+                return doViOtherwiseHdrOtherwiseSdr;
+            case "DOVIWithHDR10":
+            case "DOVIWithHLG":
+            case "HDR":
+            case "HDR10":
+            case "HDR10Plus":
+            case "HLG":
+                return hdrOtherwiseSdr;
+            case "DOVIWithSDR":
+            case "SDR":
+            case "Unknown":
+            default:
+                return HdmiDisplayHdrOption.None;
+        }
+    }
+
+    private static Func<HdmiDisplayMode, bool> RefreshRateMatches(double refreshRate)
+    {
+        return mode => Math.Abs(refreshRate - mode.RefreshRate) <= 0.5;
+    }
+
+    private static Func<HdmiDisplayMode, bool> ResolutionMatches(uint width, uint height)
+    {
+        return mode => mode.ResolutionWidthInRawPixels == width || mode.ResolutionHeightInRawPixels == height;
+    }
+
+    private static Func<HdmiDisplayMode, bool> HdmiDisplayHdrOptionMatches(HdmiDisplayHdrOption hdmiDisplayHdrOption)
+    {
+        bool HdrMatches(HdmiDisplayMode mode) =>
+            hdmiDisplayHdrOption == HdmiDisplayHdrOption.None ||
+            (hdmiDisplayHdrOption == HdmiDisplayHdrOption.DolbyVisionLowLatency && mode.IsDolbyVisionLowLatencySupported) ||
+            (hdmiDisplayHdrOption == HdmiDisplayHdrOption.Eotf2084 && mode.IsSmpte2084Supported);
+
+        return HdrMatches;
+    }
+
+    private HdmiDisplayMode GetBestDisplayMode(uint videoWidth, uint videoHeight, double videoFrameRate, HdmiDisplayHdrOption hdmiDisplayHdrOption)
+    {
+        HdmiDisplayInformation hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
+        IEnumerable<HdmiDisplayMode> supportedHdmiDisplayModes = hdmiDisplayInformation.GetSupportedDisplayModes();
+
+        // `GetHdmiDisplayHdrOption(...)` ensures the HdmiDisplayHdrOption is always a mode the display supports
+        IEnumerable<HdmiDisplayMode> hdmiDisplayModes = supportedHdmiDisplayModes.Where(HdmiDisplayHdrOptionMatches(hdmiDisplayHdrOption));
+
+        bool filteredToVideoResolution = false;
+        if (Central.Settings.AutoResolution)
+        {
+            IEnumerable<HdmiDisplayMode> matchingResolution = hdmiDisplayModes.Where(ResolutionMatches(videoWidth, videoHeight));
+            if (matchingResolution.Any())
+            {
+                hdmiDisplayModes = matchingResolution;
+                filteredToVideoResolution = true;
+            }
+        }
+
+        HdmiDisplayMode currentHdmiDisplayMode = hdmiDisplayInformation.GetCurrentDisplayMode();
+
+        if (!filteredToVideoResolution)
+        {
+            hdmiDisplayModes = hdmiDisplayModes.Where(ResolutionMatches(
+                currentHdmiDisplayMode.ResolutionWidthInRawPixels,
+                currentHdmiDisplayMode.ResolutionHeightInRawPixels));
+        }
+
+        if (Central.Settings.AutoRefreshRate)
+        {
+            IEnumerable<HdmiDisplayMode> matchingRefreshRates = hdmiDisplayModes.Where(RefreshRateMatches(videoFrameRate));
+            if (matchingRefreshRates.Any())
+            {
+                return matchingRefreshRates.First();
+            }
+        }
+
+        return hdmiDisplayModes
+            .Where(ResolutionMatches(
+                currentHdmiDisplayMode.ResolutionWidthInRawPixels,
+                currentHdmiDisplayMode.ResolutionHeightInRawPixels))
+            .Where(RefreshRateMatches(currentHdmiDisplayMode.RefreshRate))
+            .FirstOrDefault();
+    }
+
+    private async Task SetDefaultDisplayModeAsync()
+    {
+        await HdmiDisplayInformation.GetForCurrentView()?.SetDefaultDisplayModeAsync();
+    }
+
+    /// <summary>
+    /// Enables Fullscreen.
+    /// </summary>
+    /// <param name="args">JsonObject.</param>
+    /// <returns>A <see cref="Task"/> representing the result of the asynchronous operation.</returns>
+    public async Task EnableFullscreenAsync(JsonObject args)
+    {
+        if (AppUtils.IsXbox)
+        {
+            if (args != null)
+            {
+                try
+                {
+                    uint videoWidth = (uint)args.GetNamedNumber("videoWidth");
+                    uint videoHeight = (uint)args.GetNamedNumber("videoHeight");
+                    double videoFrameRate = args.GetNamedNumber("videoFrameRate");
+                    string videoRangeType = args.GetNamedString("videoRangeType");
+                    HdmiDisplayHdrOption hdmiDisplayHdrOption = GetHdmiDisplayHdrOption(videoRangeType);
+                    await SwitchToBestDisplayMode(videoWidth, videoHeight, videoFrameRate, hdmiDisplayHdrOption);
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine("Error during SwitchToBestDisplayMode", ex);
+                }
+            }
+            else
+            {
+                Debug.WriteLine("enableFullscreenAsync called with no args");
+            }
+        }
+        else
+        {
+            ApplicationView.GetForCurrentView().TryEnterFullScreenMode();
+        }
+    }
+
+    /// <summary>
+    /// Disables FullScreen.
+    /// </summary>
+    public async void DisableFullScreen()
+    {
+        if (AppUtils.IsXbox)
+        {
+            await SetDefaultDisplayModeAsync();
+        }
+        else
+        {
+            ApplicationView.GetForCurrentView().ExitFullScreenMode();
+        }
+    }
+}

--- a/Jellyfin/Core/MessageHandler.cs
+++ b/Jellyfin/Core/MessageHandler.cs
@@ -1,0 +1,74 @@
+using System.Diagnostics;
+using Jellyfin.Views;
+using Windows.Data.Json;
+using Windows.UI.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Jellyfin.Core;
+
+/// <summary>
+/// Handle Json Notification from winuwp.js.
+/// </summary>
+public class MessageHandler
+{
+    private readonly Frame _frame;
+    private readonly FullScreenManager _fullScreenManager;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="MessageHandler"/> class.
+    /// </summary>
+    /// <param name="frame">Frame.</param>
+    public MessageHandler(Frame frame)
+    {
+        _frame = frame;
+        _fullScreenManager = new FullScreenManager();
+    }
+
+    /// <summary>
+    /// Handle Json Notification from winuwp.js.
+    /// </summary>
+    /// <param name="json">JsonObject.</param>
+    public async void HandleJsonNotification(JsonObject json)
+    {
+        string eventType = json.GetNamedString("type");
+        JsonObject args = json.GetNamedObject("args");
+
+        if (eventType == "enableFullscreen")
+        {
+            await _fullScreenManager.EnableFullscreenAsync(args);
+        }
+        else if (eventType == "disableFullscreen")
+        {
+            _fullScreenManager.DisableFullScreen();
+        }
+        else if (eventType == "selectServer")
+        {
+            Central.Settings.JellyfinServer = null;
+            _ = _frame.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                _frame.Navigate(typeof(OnBoarding));
+            });
+        }
+        else if (eventType == "openClientSettings")
+        {
+            _ = _frame.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+            {
+                _frame.Navigate(typeof(Settings));
+            });
+        }
+        else if (eventType == "exit")
+        {
+            Exit();
+        }
+        else
+        {
+            Debug.WriteLine($"Unexpected JSON message: {eventType}");
+        }
+    }
+
+    private void Exit()
+    {
+        Application.Current.Exit();
+    }
+}

--- a/Jellyfin/Core/MessageHandler.cs
+++ b/Jellyfin/Core/MessageHandler.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Threading.Tasks;
 using Jellyfin.Views;
 using Windows.Data.Json;
 using Windows.UI.Core;
@@ -29,18 +30,19 @@ public class MessageHandler
     /// Handle Json Notification from winuwp.js.
     /// </summary>
     /// <param name="json">JsonObject.</param>
-    public async void HandleJsonNotification(JsonObject json)
+    /// <returns>A task that completes when the notification action has been performed.</returns>
+    public async Task HandleJsonNotification(JsonObject json)
     {
-        string eventType = json.GetNamedString("type");
-        JsonObject args = json.GetNamedObject("args");
+        var eventType = json.GetNamedString("type");
+        var args = json.GetNamedObject("args");
 
         if (eventType == "enableFullscreen")
         {
-            await _fullScreenManager.EnableFullscreenAsync(args);
+            await _fullScreenManager.EnableFullscreenAsync(args).ConfigureAwait(true);
         }
         else if (eventType == "disableFullscreen")
         {
-            _fullScreenManager.DisableFullScreen();
+            await _fullScreenManager.DisableFullScreen().ConfigureAwait(true);
         }
         else if (eventType == "selectServer")
         {

--- a/Jellyfin/Core/NativeShellScriptLoader.cs
+++ b/Jellyfin/Core/NativeShellScriptLoader.cs
@@ -15,23 +15,24 @@ namespace Jellyfin.Core;
 /// </summary>
 public static class NativeShellScriptLoader
 {
+    private static readonly Uri StorageUri = new Uri("ms-appx:///Resources/winuwp.js");
+
     /// <summary>
     /// LoadNativeShellScript.
     /// </summary>
     /// <returns><see cref="Task"/>representing the asynchronous operation.</returns>
     public static async Task<string> LoadNativeShellScript()
     {
-        Uri uri = new Uri("ms-appx:///Resources/winuwp.js");
-        StorageFile storageFile = await StorageFile.GetFileFromApplicationUriAsync(uri);
-        string nativeShellScript = await FileIO.ReadTextAsync(storageFile);
+        var storageFile = await StorageFile.GetFileFromApplicationUriAsync(StorageUri);
+        var nativeShellScript = await FileIO.ReadTextAsync(storageFile);
 
-        Assembly assembly = Assembly.GetExecutingAssembly();
+        var assembly = Assembly.GetExecutingAssembly();
         nativeShellScript = nativeShellScript.Replace(
             "APP_NAME",
             Wrap(assembly.GetCustomAttribute<AssemblyTitleAttribute>().Title, '\''));
         nativeShellScript = nativeShellScript.Replace("APP_VERSION", Wrap(assembly.GetName().Version.ToString(), '\''));
 
-        string deviceForm = AnalyticsInfo.DeviceForm;
+        var deviceForm = AnalyticsInfo.DeviceForm;
         if (deviceForm == "Unknown")
         {
             deviceForm = AppUtils.GetDeviceFormFactorType().ToString();
@@ -39,13 +40,13 @@ public static class NativeShellScriptLoader
 
         nativeShellScript = nativeShellScript.Replace("DEVICE_NAME", Wrap(deviceForm, '\''));
 
-        HdmiDisplayInformation hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
+        var hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
         if (hdmiDisplayInformation != null)
         {
-            IReadOnlyList<HdmiDisplayMode> supportedDisplayModes = hdmiDisplayInformation.GetSupportedDisplayModes();
-            bool supportsHdr = supportedDisplayModes.Any(mode => mode.IsSmpte2084Supported);
+            var supportedDisplayModes = hdmiDisplayInformation.GetSupportedDisplayModes();
+            var supportsHdr = supportedDisplayModes.Any(mode => mode.IsSmpte2084Supported);
             nativeShellScript = nativeShellScript.Replace("SUPPORTS_HDR", supportsHdr.ToString().ToLower());
-            bool supportsDovi = supportedDisplayModes.Any(mode => mode.IsDolbyVisionLowLatencySupported);
+            var supportsDovi = supportedDisplayModes.Any(mode => mode.IsDolbyVisionLowLatencySupported);
             nativeShellScript = nativeShellScript.Replace("SUPPORTS_DOVI", supportsDovi.ToString().ToLower());
         }
         else

--- a/Jellyfin/Core/NativeShellScriptLoader.cs
+++ b/Jellyfin/Core/NativeShellScriptLoader.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading.Tasks;
+using Jellyfin.Utils;
+using Windows.Graphics.Display.Core;
+using Windows.Storage;
+using Windows.System.Profile;
+
+namespace Jellyfin.Core;
+
+/// <summary>
+/// Injects the NativeShell javascript script to be able to interact with the UWP code.
+/// </summary>
+public static class NativeShellScriptLoader
+{
+    /// <summary>
+    /// LoadNativeShellScript.
+    /// </summary>
+    /// <returns><see cref="Task"/>representing the asynchronous operation.</returns>
+    public static async Task<string> LoadNativeShellScript()
+    {
+        Uri uri = new Uri("ms-appx:///Resources/winuwp.js");
+        StorageFile storageFile = await StorageFile.GetFileFromApplicationUriAsync(uri);
+        string nativeShellScript = await FileIO.ReadTextAsync(storageFile);
+
+        Assembly assembly = Assembly.GetExecutingAssembly();
+        nativeShellScript = nativeShellScript.Replace(
+            "APP_NAME",
+            Wrap(assembly.GetCustomAttribute<AssemblyTitleAttribute>().Title, '\''));
+        nativeShellScript = nativeShellScript.Replace("APP_VERSION", Wrap(assembly.GetName().Version.ToString(), '\''));
+
+        string deviceForm = AnalyticsInfo.DeviceForm;
+        if (deviceForm == "Unknown")
+        {
+            deviceForm = AppUtils.GetDeviceFormFactorType().ToString();
+        }
+
+        nativeShellScript = nativeShellScript.Replace("DEVICE_NAME", Wrap(deviceForm, '\''));
+
+        HdmiDisplayInformation hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
+        if (hdmiDisplayInformation != null)
+        {
+            IReadOnlyList<HdmiDisplayMode> supportedDisplayModes = hdmiDisplayInformation.GetSupportedDisplayModes();
+            bool supportsHdr = supportedDisplayModes.Any(mode => mode.IsSmpte2084Supported);
+            nativeShellScript = nativeShellScript.Replace("SUPPORTS_HDR", supportsHdr.ToString().ToLower());
+            bool supportsDovi = supportedDisplayModes.Any(mode => mode.IsDolbyVisionLowLatencySupported);
+            nativeShellScript = nativeShellScript.Replace("SUPPORTS_DOVI", supportsDovi.ToString().ToLower());
+        }
+        else
+        {
+            nativeShellScript = nativeShellScript.Replace("SUPPORTS_HDR", "undefined");
+            nativeShellScript = nativeShellScript.Replace("SUPPORTS_DOVI", "undefined");
+        }
+
+        return nativeShellScript;
+    }
+
+    private static string Wrap(string text, char c)
+    {
+        return c + text + c;
+    }
+}

--- a/Jellyfin/Core/SettingsManager.cs
+++ b/Jellyfin/Core/SettingsManager.cs
@@ -9,6 +9,8 @@ public class SettingsManager
 {
     private string _containerSettings = "APPSETTINGS";
     private string _settingsServer = "SERVER";
+    private string _autoResolution = "AUTO_RESOLUTION";
+    private string _autoRefreshRate = "AUTO_REFRESH_RATE";
 
     private ApplicationDataContainer LocalSettings => ApplicationData.Current.LocalSettings;
 
@@ -43,6 +45,24 @@ public class SettingsManager
     /// Gets a value indicating whether the state of the <see cref="JellyfinServer"/>s validation state.
     /// </summary>
     public bool JellyfinServerValidated { get; internal set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the display resolution should be set to match the video resolution.
+    /// </summary>
+    public bool AutoResolution
+    {
+        get => GetProperty<bool>(_autoResolution);
+        set => SetProperty(_autoResolution, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the display refresh rate should be set to match the video refresh rate.
+    /// </summary>
+    public bool AutoRefreshRate
+    {
+        get => GetProperty<bool>(_autoRefreshRate);
+        set => SetProperty(_autoRefreshRate, value);
+    }
 
     private void SetProperty(string propertyName, object value)
     {

--- a/Jellyfin/Jellyfin.csproj
+++ b/Jellyfin/Jellyfin.csproj
@@ -136,6 +136,9 @@
       <DependentUpon>JellyfinWebView.xaml</DependentUpon>
     </Compile>
     <Compile Include="Core\Central.cs" />
+    <Compile Include="Core\FullScreenManager.cs" />
+    <Compile Include="Core\MessageHandler.cs" />
+    <Compile Include="Core\NativeShellScriptLoader.cs" />
     <Compile Include="Core\SettingsManager.cs" />
     <Compile Include="Helpers\UrlValidator.cs" />
     <Compile Include="MainPage.xaml.cs">
@@ -151,6 +154,9 @@
     <Compile Include="Utils\ServerCheckUtil.cs" />
     <Compile Include="Views\OnBoarding.xaml.cs">
       <DependentUpon>OnBoarding.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="Views\Settings.xaml.cs">
+      <DependentUpon>Settings.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -207,6 +213,7 @@
     <Content Include="Assets\Wide310x150Logo.scale-150.png" />
     <Content Include="Assets\Wide310x150Logo.scale-400.png" />
     <Content Include="Fonts\NotoSans-Regular.ttf" />
+    <Content Include="Resources\winuwp.js" />
     <None Include="Package.StoreAssociation.xml" />
     <Content Include="Properties\Default.rd.xml" />
     <Content Include="Assets\SplashScreen.scale-200.png" />
@@ -237,6 +244,10 @@
       <SubType>Designer</SubType>
     </Page>
     <Page Include="Views\OnBoarding.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Views\Settings.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
     </Page>

--- a/Jellyfin/Jellyfin.csproj
+++ b/Jellyfin/Jellyfin.csproj
@@ -135,6 +135,8 @@
     <Compile Include="Controls\JellyfinWebView.xaml.cs">
       <DependentUpon>JellyfinWebView.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Converter\BooleanVisibilityConverter.cs" />
+    <Compile Include="Converter\BooleanVisibilityInverseConverter.cs" />
     <Compile Include="Core\Central.cs" />
     <Compile Include="Core\FullScreenManager.cs" />
     <Compile Include="Core\MessageHandler.cs" />
@@ -293,4 +295,5 @@
     <PackageReference Include="StyleCop.Analyzers" PrivateAssets="All" />
     <PackageReference Include="SmartAnalyzers.MultithreadingAnalyzer" PrivateAssets="All" />
   </ItemGroup>
+  <ItemGroup />
 </Project>

--- a/Jellyfin/Resources/JellyfinStyleResources.DeviceFamily-Desktop.xaml
+++ b/Jellyfin/Resources/JellyfinStyleResources.DeviceFamily-Desktop.xaml
@@ -2,22 +2,10 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <SolidColorBrush x:Key="Color0" Color="#101010" />
-    <SolidColorBrush x:Key="Color10" Color="#202020" />
-    <SolidColorBrush x:Key="Color20" Color="#303030" />
-    <SolidColorBrush x:Key="Color80" Color="#828282" />
-    <SolidColorBrush x:Key="Color90" Color="#a9a9a9" />
-    <SolidColorBrush x:Key="Color100" Color="#FFFFFF" />
-    <SolidColorBrush x:Key="PrimaryColor" Color="#00A4DC" />
-    <SolidColorBrush x:Key="PrimaryColorHover" Color="#0CB0E8" />
-    <SolidColorBrush x:Key="OverlayColorBG" Color="LightGray" Opacity="0.2" />
-
     <x:Double x:Key="FontS">14</x:Double>
     <x:Double x:Key="FontM">16</x:Double>
     <x:Double x:Key="FontL">20</x:Double>
 
-
-    <FontFamily x:Key="JellyfinFamilyFont">/Fonts/NotoSans-Regular.ttf#Noto Sans</FontFamily>
 
     <!-- Default style for Windows.UI.Xaml.Controls.Button -->
     <Style x:Key="PrimaryButton" TargetType="Button">
@@ -83,15 +71,82 @@
 
                         </VisualStateManager.VisualStateGroups>
                         <ContentPresenter x:Name="ContentPresenter"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Content="{TemplateBinding Content}"
-                            ContentTransitions="{TemplateBinding ContentTransitions}"
-                            ContentTemplate="{TemplateBinding ContentTemplate}"
-                            Padding="{TemplateBinding Padding}"
-                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                            AutomationProperties.AccessibilityView="Raw" />
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Content="{TemplateBinding Content}"
+                        ContentTransitions="{TemplateBinding ContentTransitions}"
+                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                        Padding="{TemplateBinding Padding}"
+                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                        AutomationProperties.AccessibilityView="Raw" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="SecondaryButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="RootGrid" Background="{StaticResource SecondaryColor}" CornerRadius="4">
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal">
+
+                                    <Storyboard>
+                                        <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="PointerOver">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource SecondaryColorHover}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Pressed">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource SecondaryColorHover}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <PointerDownThemeAnimation Storyboard.TargetName="RootGrid" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Disabled">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource Color20}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource Color80}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+
+                        </VisualStateManager.VisualStateGroups>
+                        <ContentPresenter x:Name="ContentPresenter"
+                        BorderBrush="{TemplateBinding BorderBrush}"
+                        BorderThickness="{TemplateBinding BorderThickness}"
+                        Content="{TemplateBinding Content}"
+                        ContentTransitions="{TemplateBinding ContentTransitions}"
+                        ContentTemplate="{TemplateBinding ContentTemplate}"
+                        Padding="{TemplateBinding Padding}"
+                        Height="{TemplateBinding Height}"
+                        Width="{TemplateBinding Width}"
+                        HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                        VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                        AutomationProperties.AccessibilityView="Raw" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/Jellyfin/Resources/JellyfinStyleResources.xaml
+++ b/Jellyfin/Resources/JellyfinStyleResources.xaml
@@ -2,16 +2,6 @@
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation" 
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
 
-    <SolidColorBrush x:Key="Color0" Color="#101010" />
-    <SolidColorBrush x:Key="Color10" Color="#202020" />
-    <SolidColorBrush x:Key="Color20" Color="#303030" />
-    <SolidColorBrush x:Key="Color80" Color="#828282" />
-    <SolidColorBrush x:Key="Color90" Color="#a9a9a9" />
-    <SolidColorBrush x:Key="Color100" Color="#FFFFFF" />
-    <SolidColorBrush x:Key="PrimaryColor" Color="#00A4DC" />
-    <SolidColorBrush x:Key="PrimaryColorHover" Color="#0CB0E8" />
-    <SolidColorBrush x:Key="OverlayColorBG" Color="LightGray" Opacity="0.2" />
-
     <x:Double x:Key="FontS">24</x:Double>
     <x:Double x:Key="FontM">28</x:Double>
     <x:Double x:Key="FontL">32</x:Double>
@@ -82,15 +72,81 @@
 
                         </VisualStateManager.VisualStateGroups>
                         <ContentPresenter x:Name="ContentPresenter"
-                            BorderBrush="{TemplateBinding BorderBrush}"
-                            BorderThickness="{TemplateBinding BorderThickness}"
-                            Content="{TemplateBinding Content}"
-                            ContentTransitions="{TemplateBinding ContentTransitions}"
-                            ContentTemplate="{TemplateBinding ContentTemplate}"
-                            Padding="{TemplateBinding Padding}"
-                            HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
-                            VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
-                            AutomationProperties.AccessibilityView="Raw" />
+                         BorderBrush="{TemplateBinding BorderBrush}"
+                         BorderThickness="{TemplateBinding BorderThickness}"
+                         Content="{TemplateBinding Content}"
+                         ContentTransitions="{TemplateBinding ContentTransitions}"
+                         ContentTemplate="{TemplateBinding ContentTemplate}"
+                         Padding="{TemplateBinding Padding}"
+                         HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                         AutomationProperties.AccessibilityView="Raw" />
+                    </Border>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+    <Style x:Key="SecondaryButton" TargetType="Button" BasedOn="{StaticResource PrimaryButton}">
+        <Setter Property="FontSize" Value="{StaticResource FontM}" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="Button">
+                    <Border x:Name="RootGrid" Background="{StaticResource SecondaryColor}" CornerRadius="4">
+
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup x:Name="CommonStates">
+                                <VisualState x:Name="Normal">
+
+                                    <Storyboard>
+                                        <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="PointerOver">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource SecondaryColorHover}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <PointerUpThemeAnimation Storyboard.TargetName="RootGrid" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Pressed">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource SecondaryColorHover}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <PointerDownThemeAnimation Storyboard.TargetName="RootGrid" />
+                                    </Storyboard>
+                                </VisualState>
+
+                                <VisualState x:Name="Disabled">
+
+                                    <Storyboard>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="RootGrid" Storyboard.TargetProperty="Background">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource Color20}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetName="ContentPresenter" Storyboard.TargetProperty="Foreground">
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{StaticResource Color80}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                    </Storyboard>
+                                </VisualState>
+                            </VisualStateGroup>
+
+                        </VisualStateManager.VisualStateGroups>
+                        <ContentPresenter x:Name="ContentPresenter"
+                         BorderBrush="{TemplateBinding BorderBrush}"
+                         BorderThickness="{TemplateBinding BorderThickness}"
+                         Content="{TemplateBinding Content}"
+                         ContentTransitions="{TemplateBinding ContentTransitions}"
+                         ContentTemplate="{TemplateBinding ContentTemplate}"
+                         Padding="{TemplateBinding Padding}"
+                         HorizontalContentAlignment="{TemplateBinding HorizontalContentAlignment}"
+                         VerticalContentAlignment="{TemplateBinding VerticalContentAlignment}"
+                         AutomationProperties.AccessibilityView="Raw" />
                     </Border>
                 </ControlTemplate>
             </Setter.Value>

--- a/Jellyfin/Resources/winuwp.js
+++ b/Jellyfin/Resources/winuwp.js
@@ -45,10 +45,7 @@
         SupportedFeatures.push('physicalvolumecontrol');
     }
 
-    // Only devices with HdmiDisplayInformation have settings currently
-    if (xbox) {
-        SupportedFeatures.push('clientsettings');
-    }
+    SupportedFeatures.push('clientsettings');
 
     console.debug('SupportedFeatures', SupportedFeatures);
 

--- a/Jellyfin/Resources/winuwp.js
+++ b/Jellyfin/Resources/winuwp.js
@@ -1,0 +1,140 @@
+(function (appName, appVersion, deviceName, supportsHdr10, supportsDolbyVision) {
+    'use strict';
+
+    console.log('Windows UWP adapter');
+
+    const xbox = deviceName.toLowerCase().indexOf('xbox') !== -1;
+    const xboxSeries = deviceName.toLowerCase().indexOf('xbox series') !== -1;
+    const mobile = deviceName.toLowerCase().indexOf('mobile') !== -1;
+
+    function postMessage(type, args = {}) {
+        console.debug(`AppHost.${type}`, args);
+        const payload = {
+            'type': type,
+            'args': args
+        };
+
+        window.chrome.webview.postMessage(JSON.stringify(payload));
+    }
+
+    const AppInfo = {
+        deviceName: deviceName,
+        appName: appName,
+        appVersion: appVersion
+    };
+
+    // List of supported features
+    const SupportedFeatures = [
+        'displaylanguage',
+        'displaymode',
+        'exit',
+        'exitmenu',
+        'externallinkdisplay',
+        'externallinks',
+        'htmlaudioautoplay',
+        'htmlvideoautoplay',
+        'multiserver',
+        'otherapppromotions',
+        'screensaver',
+        'subtitleappearancesettings',
+        'subtitleburnsettings',
+        'targetblank'
+    ];
+
+    if (xbox || mobile) {
+        SupportedFeatures.push('physicalvolumecontrol');
+    }
+
+    // Only devices with HdmiDisplayInformation have settings currently
+    if (xbox) {
+        SupportedFeatures.push('clientsettings');
+    }
+
+    console.debug('SupportedFeatures', SupportedFeatures);
+
+    window.NativeShell = {
+        AppHost: {
+            init: function () {
+                console.debug('AppHost.init', AppInfo);
+                return Promise.resolve(AppInfo);
+            },
+
+            appName: function () {
+                console.debug('AppHost.appName', AppInfo.appName);
+                return AppInfo.appName;
+            },
+
+            appVersion: function () {
+                console.debug('AppHost.appVersion', AppInfo.appVersion);
+                return AppInfo.appVersion;
+            },
+
+            deviceName: function () {
+                console.debug('AppHost.deviceName', AppInfo.deviceName);
+                return AppInfo.deviceName;
+            },
+
+            exit: function () {
+                postMessage('exit');
+            },
+
+            getDefaultLayout: function () {
+                let layout;
+                if (xbox) {
+                    layout = 'tv';
+                } else if (mobile) {
+                    layout = 'mobile';
+                } else {
+                    layout = 'desktop';
+                }
+                console.debug('AppHost.getDefaultLayout', layout);
+                return layout;
+            },
+
+            getDeviceProfile: function (profileBuilder) {
+                console.debug('AppHost.getDeviceProfile');
+                const options = {};
+                if (supportsHdr10 != null) {
+                    options.supportsHdr10 = supportsHdr10;
+                }
+                if (supportsDolbyVision != null) {
+                    options.supportsDolbyVision = supportsDolbyVision;
+                }
+                if (xboxSeries) {
+                    options.maxVideoWidth = 3840;
+                }
+                return profileBuilder(options);
+            },
+
+            supports: function (command) {
+                const isSupported = command && SupportedFeatures.indexOf(command.toLowerCase()) !== -1;
+                console.debug('AppHost.supports', {
+                    command: command,
+                    isSupported: isSupported
+                });
+                return isSupported;
+            }
+        },
+
+        enableFullscreen: function (videoInfo) {
+            postMessage('enableFullscreen', videoInfo);
+        },
+
+        disableFullscreen: function () {
+            postMessage('disableFullscreen');
+        },
+
+        getPlugins: function () {
+            console.debug('getPlugins');
+            return [];
+        },
+
+        selectServer: function () {
+            postMessage('selectServer');
+        },
+
+        openClientSettings: function () {
+            postMessage('openClientSettings');
+        }
+    };
+})(APP_NAME, APP_VERSION, DEVICE_NAME, SUPPORTS_HDR, SUPPORTS_DOVI);

--- a/Jellyfin/Views/Settings.xaml
+++ b/Jellyfin/Views/Settings.xaml
@@ -1,14 +1,28 @@
-﻿<Page
+<Page
     x:Class="Jellyfin.Views.Settings"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Jellyfin.Views"
     xmlns:c="using:Jellyfin.Controls"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    Background="{StaticResource Color0}"
     mc:Ignorable="d">
 
-    <Grid Background="{StaticResource Color0}">
+    <Page.Resources>
+        <ResourceDictionary>
+            <DataTemplate x:Key="CheckboxContentTemplate">
+                <TextBlock Text="{Binding}" 
+                           Foreground="White"
+                           FontSize="{StaticResource FontL}"/>
+            </DataTemplate>
+            <Style TargetType="CheckBox">
+                <Setter Property="ContentTemplate" Value="{StaticResource CheckboxContentTemplate}"/>
+            </Style>
+        </ResourceDictionary>
+    </Page.Resources>
+
+    <Grid 
+        VerticalAlignment="Top" >
         <VisualStateManager.VisualStateGroups>
             <VisualStateGroup>
 
@@ -17,44 +31,88 @@
                         <c:DeviceFamilyStateTrigger TargetDeviceFamily="Desktop" />
                     </VisualState.StateTriggers>
                     <VisualState.Setters>
-                        <Setter Target="RowHeader.Height" Value="60" />
-                        <Setter Target="logo.HorizontalAlignment" Value="Left" />
-                        <Setter Target="logo.Height" Value="28" />
-                        <Setter Target="logo.Margin" Value="28 0 0 0" />
-                        <Setter Target="txtTitle.FontSize" Value="22" />
-                        <Setter Target="pnlMain.MaxWidth" Value="400" />
+                        <Setter Target="Image.HorizontalAlignment" Value="Left" />
+                        <Setter Target="Image.Height" Value="28" />
+                        <Setter Target="Image.Margin" Value="28 0 0 0" />
+                        <Setter Target="TextBox.FontSize" Value="22" />
+                        <Setter Target="TextBox.MaxWidth" Value="400" />
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
         </VisualStateManager.VisualStateGroups>
         <Grid.RowDefinitions>
-            <RowDefinition x:Name="RowHeader" Height="200" />
+            <RowDefinition />
             <RowDefinition />
         </Grid.RowDefinitions>
 
-        <StackPanel 
-                x:Name="pnlMain" 
+        <Grid Background="{StaticResource Color10}">
+            <Image 
+                x:Name="logo" 
+                Source="/Assets/OnBoardingLogo.png" 
+                Stretch="Uniform" 
                 HorizontalAlignment="Center" 
-                VerticalAlignment="Top" 
-                Width="640">
-            <TextBlock
-                    x:Name="txtTitle"
-                    Text="Settings" 
-                    Foreground="White" FontSize="{StaticResource FontL}"
-                    Margin="0 0 0 28" FontFamily="{StaticResource JellyfinFamilyFont}"
-                    HorizontalAlignment="Center" />
+                Height="80" />
+        </Grid>
+
+        <Grid
+            Grid.Row="1"
+            HorizontalAlignment="Center"
+            Margin="0,30,0,0"
+            Width="640">
+
+            <Grid.RowDefinitions>
+                <RowDefinition />
+                <RowDefinition />
+                <RowDefinition />
+                <RowDefinition />
+                <RowDefinition />
+            </Grid.RowDefinitions>
 
             <CheckBox 
-                    x:Name="checkBoxAutoRefreshRate"
-                    Content="Set the display refresh rate to the media refresh rate" />
+                x:Name="checkBoxAutoRefreshRate"
+                Grid.Row="0"
+                Content="Set the display refresh rate to the media refresh rate">
+            </CheckBox>
+            <TextBlock Visibility="{Binding ElementName=checkBoxAutoRefreshRate, Path=IsEnabled, Converter={StaticResource BooleanVisibilityInverseConverter}}"
+                       Grid.Row="1"
+                       FontSize="{StaticResource FontM}"
+                       Foreground="#CF4A4A" >
+                Auto display refresh rate is not supported on this device.
+            </TextBlock>
+
             <CheckBox 
-                    x:Name="checkBoxAutoResolution"
-                    Content="Set the display resolution to the media resolution" />
-            <Button
+                x:Name="checkBoxAutoResolution"
+                Content="Set the display resolution to the media resolution"
+                Foreground="White" FontSize="{StaticResource FontL}"
+                Grid.Row="2"/>
+            <TextBlock Visibility="{Binding ElementName=checkBoxAutoRefreshRate, Path=IsEnabled, Converter={StaticResource BooleanVisibilityInverseConverter}}"
+                       Grid.Row="3"
+                       FontSize="{StaticResource FontM}"
+                       Foreground="#CF4A4A" >
+                Display resolution is not supported on this device.
+            </TextBlock>
+
+            <Grid
+                HorizontalAlignment="Stretch"
+                Margin="0,30,0,0"
+                Grid.Row="4">
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition />
+                    <ColumnDefinition />
+                </Grid.ColumnDefinitions>
+                <Button
+                    x:Name="btnAbort"
+                    Grid.Column="0"
+                    Style="{StaticResource SecondaryButton}"
+                    Content="Abort"  />
+                <Button
                     x:Name="btnSave"
+                    Grid.Column="1"
                     Style="{StaticResource PrimaryButton}"
                     Content="Save"  />
-        </StackPanel>
+            </Grid>
 
+            
+        </Grid>
     </Grid>
 </Page>

--- a/Jellyfin/Views/Settings.xaml
+++ b/Jellyfin/Views/Settings.xaml
@@ -1,0 +1,60 @@
+﻿<Page
+    x:Class="Jellyfin.Views.Settings"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Jellyfin.Views"
+    xmlns:c="using:Jellyfin.Controls"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <Grid Background="{StaticResource Color0}">
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+
+                <VisualState>
+                    <VisualState.StateTriggers>
+                        <c:DeviceFamilyStateTrigger TargetDeviceFamily="Desktop" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="RowHeader.Height" Value="60" />
+                        <Setter Target="logo.HorizontalAlignment" Value="Left" />
+                        <Setter Target="logo.Height" Value="28" />
+                        <Setter Target="logo.Margin" Value="28 0 0 0" />
+                        <Setter Target="txtTitle.FontSize" Value="22" />
+                        <Setter Target="pnlMain.MaxWidth" Value="400" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+        <Grid.RowDefinitions>
+            <RowDefinition x:Name="RowHeader" Height="200" />
+            <RowDefinition />
+        </Grid.RowDefinitions>
+
+        <StackPanel 
+                x:Name="pnlMain" 
+                HorizontalAlignment="Center" 
+                VerticalAlignment="Top" 
+                Width="640">
+            <TextBlock
+                    x:Name="txtTitle"
+                    Text="Settings" 
+                    Foreground="White" FontSize="{StaticResource FontL}"
+                    Margin="0 0 0 28" FontFamily="{StaticResource JellyfinFamilyFont}"
+                    HorizontalAlignment="Center" />
+
+            <CheckBox 
+                    x:Name="checkBoxAutoRefreshRate"
+                    Content="Set the display refresh rate to the media refresh rate" />
+            <CheckBox 
+                    x:Name="checkBoxAutoResolution"
+                    Content="Set the display resolution to the media resolution" />
+            <Button
+                    x:Name="btnSave"
+                    Style="{StaticResource PrimaryButton}"
+                    Content="Save"  />
+        </StackPanel>
+
+    </Grid>
+</Page>

--- a/Jellyfin/Views/Settings.xaml.cs
+++ b/Jellyfin/Views/Settings.xaml.cs
@@ -3,50 +3,49 @@ using Windows.Graphics.Display.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 
-namespace Jellyfin.Views
+namespace Jellyfin.Views;
+
+/// <summary>
+/// Settings page.
+/// </summary>
+public sealed partial class Settings : Page
 {
     /// <summary>
-    /// Settings page.
+    /// Initializes a new instance of the <see cref="Settings"/> class.
     /// </summary>
-    public sealed partial class Settings : Page
+    public Settings()
     {
-        /// <summary>
-        /// Initializes a new instance of the <see cref="Settings"/> class.
-        /// </summary>
-        public Settings()
-        {
-            this.InitializeComponent();
-            btnSave.Click += BtnSave_Click;
+        InitializeComponent();
+        btnSave.Click += BtnSave_Click;
 
-            HdmiDisplayInformation hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
-            checkBoxAutoRefreshRate.IsEnabled = hdmiDisplayInformation != null;
-            checkBoxAutoRefreshRate.IsChecked = Central.Settings.AutoRefreshRate;
-            checkBoxAutoResolution.IsEnabled = hdmiDisplayInformation != null;
-            checkBoxAutoResolution.IsChecked = Central.Settings.AutoResolution;
+        HdmiDisplayInformation hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
+        checkBoxAutoRefreshRate.IsEnabled = hdmiDisplayInformation != null;
+        checkBoxAutoRefreshRate.IsChecked = Central.Settings.AutoRefreshRate;
+        checkBoxAutoResolution.IsEnabled = hdmiDisplayInformation != null;
+        checkBoxAutoResolution.IsChecked = Central.Settings.AutoResolution;
+    }
+
+    private void BtnSave_Click(object sender, RoutedEventArgs e)
+    {
+        SaveSettings();
+        NavigateToMainPage();
+    }
+
+    private void SaveSettings()
+    {
+        if (checkBoxAutoRefreshRate.IsEnabled)
+        {
+            Central.Settings.AutoRefreshRate = checkBoxAutoRefreshRate.IsChecked ?? false;
         }
 
-        private void BtnSave_Click(object sender, RoutedEventArgs e)
+        if (checkBoxAutoResolution.IsEnabled)
         {
-            SaveSettings();
-            NavigateToMainPage();
+            Central.Settings.AutoResolution = checkBoxAutoResolution.IsChecked ?? false;
         }
+    }
 
-        private void SaveSettings()
-        {
-            if (checkBoxAutoRefreshRate.IsEnabled)
-            {
-                Central.Settings.AutoRefreshRate = checkBoxAutoRefreshRate.IsChecked ?? false;
-            }
-
-            if (checkBoxAutoResolution.IsEnabled)
-            {
-                Central.Settings.AutoResolution = checkBoxAutoResolution.IsChecked ?? false;
-            }
-        }
-
-        private static void NavigateToMainPage()
-        {
-            (Window.Current.Content as Frame).Navigate(typeof(MainPage));
-        }
+    private static void NavigateToMainPage()
+    {
+        (Window.Current.Content as Frame).Navigate(typeof(MainPage));
     }
 }

--- a/Jellyfin/Views/Settings.xaml.cs
+++ b/Jellyfin/Views/Settings.xaml.cs
@@ -1,0 +1,52 @@
+using Jellyfin.Core;
+using Windows.Graphics.Display.Core;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+
+namespace Jellyfin.Views
+{
+    /// <summary>
+    /// Settings page.
+    /// </summary>
+    public sealed partial class Settings : Page
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Settings"/> class.
+        /// </summary>
+        public Settings()
+        {
+            this.InitializeComponent();
+            btnSave.Click += BtnSave_Click;
+
+            HdmiDisplayInformation hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
+            checkBoxAutoRefreshRate.IsEnabled = hdmiDisplayInformation != null;
+            checkBoxAutoRefreshRate.IsChecked = Central.Settings.AutoRefreshRate;
+            checkBoxAutoResolution.IsEnabled = hdmiDisplayInformation != null;
+            checkBoxAutoResolution.IsChecked = Central.Settings.AutoResolution;
+        }
+
+        private void BtnSave_Click(object sender, RoutedEventArgs e)
+        {
+            SaveSettings();
+            NavigateToMainPage();
+        }
+
+        private void SaveSettings()
+        {
+            if (checkBoxAutoRefreshRate.IsEnabled)
+            {
+                Central.Settings.AutoRefreshRate = checkBoxAutoRefreshRate.IsChecked ?? false;
+            }
+
+            if (checkBoxAutoResolution.IsEnabled)
+            {
+                Central.Settings.AutoResolution = checkBoxAutoResolution.IsChecked ?? false;
+            }
+        }
+
+        private static void NavigateToMainPage()
+        {
+            (Window.Current.Content as Frame).Navigate(typeof(MainPage));
+        }
+    }
+}

--- a/Jellyfin/Views/Settings.xaml.cs
+++ b/Jellyfin/Views/Settings.xaml.cs
@@ -17,12 +17,18 @@ public sealed partial class Settings : Page
     {
         InitializeComponent();
         btnSave.Click += BtnSave_Click;
+        btnAbort.Click += BtnAbort_Click;
 
         HdmiDisplayInformation hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
         checkBoxAutoRefreshRate.IsEnabled = hdmiDisplayInformation != null;
         checkBoxAutoRefreshRate.IsChecked = Central.Settings.AutoRefreshRate;
         checkBoxAutoResolution.IsEnabled = hdmiDisplayInformation != null;
         checkBoxAutoResolution.IsChecked = Central.Settings.AutoResolution;
+    }
+
+    private void BtnAbort_Click(object sender, RoutedEventArgs e)
+    {
+        NavigateToMainPage();
     }
 
     private void BtnSave_Click(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Implement Jellyfin NativeShell to support DoVi playback
The Xbox must be switched to DoVi mode otherwise videos fail to play.
As a HdmiDisplayMode that supports DoVi must be chosen, the HdmiDisplayMode that best matches the video is alson chosen.

Tested on Xbox Series X.

Requires
- https://github.com/jellyfin/jellyfin-web/pull/6900