### PR TITLE
Enable 4K/HEVC flag

### DIFF
--- a/Jellyfin/Package.appxmanifest
+++ b/Jellyfin/Package.appxmanifest
@@ -4,7 +4,8 @@
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
-  IgnorableNamespaces="uap mp">
+  xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
+  IgnorableNamespaces="uap mp rescap">
 
   <Identity
     Name="20468Jellyfin.Jellyfin"
@@ -44,7 +45,15 @@
   </Applications>
 
   <Capabilities>
-    <Capability Name="internetClient" />
+	<Capability Name="internetClient" />
     <Capability Name="privateNetworkClientServer"/>
+
+	  <!-- 
+	  The "hevcPlayback" capability grants the app the ability to play 4K video content on Xbox.
+         Usage of this capability requires approval from Microsoft. Work with your Microsoft
+         business representative if you need this capability.
+      -->
+	<rescap:Capability Name="hevcPlayback" />
+	  
   </Capabilities>
 </Package>


### PR DESCRIPTION
Enabled playback of 4K/HDR/HEVC media natively on supported devices

https://learn.microsoft.com/en-us/windows/uwp/audio-video-camera/hevc-xbox#enabling-4k-playback-in-your-appxmanifest