### PR TITLE
Add XML doc block for JellyfinWebView class

### DIFF
--- a/Jellyfin/Controls/JellyfinWebView.xaml.cs
+++ b/Jellyfin/Controls/JellyfinWebView.xaml.cs
@@ -10,6 +10,9 @@ using Windows.UI.Xaml.Controls;
 
 namespace Jellyfin.Controls;
 
+/// <summary>
+/// Represents a custom web view control for interacting with a Jellyfin server.
+/// </summary>
 public sealed partial class JellyfinWebView : UserControl, IDisposable
 {
     private readonly GamepadManager _gamepadManager;


### PR DESCRIPTION
Stylecop is complaining without it. This should please the stylecop.