### PR TITLE
Fix HDMI display mode switching for Dolby Vision content

### DIFF
--- a/Jellyfin/Resources/winuwp.js
+++ b/Jellyfin/Resources/winuwp.js
@@ -193,7 +193,7 @@ class UwpXboxHdmiSetupPlugin {
                     'videoWidth': stream.Width,
                     'videoHeight': stream.Height,
                     'videoFrameRate': (stream.AverageFrameRate || stream.RealFrameRate),
-                    'videoRangeType': stream.VideoRange
+                    'videoRangeType': stream.VideoRangeType
                 }
             };
 


### PR DESCRIPTION
The `UwpXboxHdmiSetupPlugin` reads the video stream's `VideoRange` property to determine the HDR type for HDMI display mode switching. However, the Jellyfin API has two distinct properties:
* VideoRange: a coarse enum with only three values: Unknown, SDR, HDR
* VideoRangeType - a detailed enum with values like SDR, HDR10, HLG, DOVI, DOVIWithHDR10, DOVIWithHLG, DOVIWithSDR, HDR10Plus, etc.

The C# `FullScreenManager.GetHdmiDisplayHdrOption()` switch statement expects the detailed `VideoRangeType` values (e.g. "DOVI", "DOVIWithHDR10", "HDR10"), but the JavaScript was sending `stream.VideoRange` which collapses all HDR variants to just "HDR".

This means that:
* Dolby Vision Profile 5 content - VideoRange returns "HDR", which matches the `case "HDR":` branch and selects Eotf2084 (HDR10 mode). The display never enters DolbyVisionLowLatency mode, even when both the content and display support it.
* DOVIWithSDR content - VideoRange returns "SDR", hitting the SDR path. The display stays in SDR mode rather than being handled by the dedicated `case "DOVIWithSDR":`.
* HDR10 vs HLG distinction - Both return "HDR" from VideoRange. While they happen to map to the same Eotf2084 display option today, using the correct property future-proofs against any distinction that may be added later.

Generic HDR10 content was not affected since "HDR" correctly mapped to Eotf2084 mode via the existing case "HDR": fallback.

This change simply changes `stream.VideoRange` to `stream.VideoRangeType` so the detailed video range type string is sent to the C# HDMI display mode switching logic, allowing each switch case to match correctly.