### PR TITLE
Fix mediaSourceId casing in UwpXboxHdmiSetupPlugin

### DIFF
--- a/Jellyfin/Resources/winuwp.js
+++ b/Jellyfin/Resources/winuwp.js
@@ -156,7 +156,7 @@ class UwpXboxHdmiSetupPlugin {
             return;
         }
         if ("mediaSourceId" in options) {
-            const mediaSourceid = options.mediaSourceid;
+            const mediaSourceid = options.mediaSourceId;
             var mediaStreams = null;
             var mediaSource = null;
 
@@ -170,7 +170,7 @@ class UwpXboxHdmiSetupPlugin {
                     });
             }
             else {
-                mediaSource = item.MediaSources.find(e => e.id == mediaSourceid);
+                mediaSource = item.MediaSources.find(e => e.Id == mediaSourceid);
                 if (mediaSource == null) {
                     return;
                 }


### PR DESCRIPTION
The `UwpXboxHdmiSetupPlugin.intercept()` method has two property casing mismatches that prevent HDMI display mode switching when `item.MediaSources` is already populated on the play options.

1. `options.mediaSourceid` (lowercase i) - the property from jellyfin-web's `playbackmanager.js` is `mediaSourceId` (capital I). The `in` check on line 158 uses the correct casing, so it passes, but the read on line 159 uses the wrong casing and always gets `undefined`.
2. `e.id` (lowercase) on the `MediaSources.find()` - the Jellyfin API returns MediaSource objects with PascalCase Id.

There are two code paths for resolving media streams:
* `item.MediaSources == null` (line 163): Falls back to an API call using `mediaSourceid || item.Id`. Because `mediaSourceid` is `undefined`, this always uses `item.Id` as a fallback. This path happens to work in most cases but may fetch the wrong media source for items with multiple versions.
* `item.MediaSources != null` (line 172): Tries `item.MediaSources.find(e => e.id == undefined)`, which never matches. The function returns early without sending the `enableFullscreen` message, so no HDMI display mode switching occurs - the display stays in its current mode instead of switching to match the video's resolution, refresh rate, and HDR format.