### PR TITLE
Remove unreachable duplicate 'info' case in log switch

### DIFF
--- a/Jellyfin/Core/MessageHandler.cs
+++ b/Jellyfin/Core/MessageHandler.cs
@@ -104,9 +104,6 @@ public class MessageHandler : IMessageHandler
                 case "debug":
                     _webviewLogger.LogDebug(args.GetNamedValue("messages").ToString());
                     break;
-                case "info":
-                    _webviewLogger.LogInformation(args.GetNamedValue("messages").ToString());
-                    break;
                 case "error":
                     _webviewLogger.LogError(args.GetNamedValue("messages").ToString());
                     break;


### PR DESCRIPTION
The log level switch in `MessageHandler` had a standalone case "info" that always matched before the case "info" or "log" pattern below it, making the "info" half of the combined pattern unreachable dead code.

Removed the standalone case so both "info" and "log" levels are handled by the single combined pattern.

No behavioral change, just dead code cleanup.