### PR TITLE
Fix display mode fallback to correctly filter by refresh rate

### DIFF
--- a/Jellyfin/Core/FullScreenManager.cs
+++ b/Jellyfin/Core/FullScreenManager.cs
@@ -99,7 +99,7 @@ public sealed class FullScreenManager : IFullScreenManager
 
     private static Func<HdmiDisplayMode, bool> MinRefreshRateMatches(double refreshRate)
     {
-        return mode => refreshRate > mode.RefreshRate;
+        return mode => mode.RefreshRate >= refreshRate;
     }
 
     private static Func<HdmiDisplayMode, bool> ResolutionMatches(uint width, uint height)
@@ -147,7 +147,7 @@ public sealed class FullScreenManager : IFullScreenManager
 
         return hdmiDisplayModes
             .Where(MinResolutionMatches(videoWidth, videoHeight))
-            .Where(MinRefreshRateMatches(videoHeight - 3))
+            .Where(MinRefreshRateMatches(videoFrameRate))
             .OrderBy(e => e.ResolutionHeightInRawPixels * e.ResolutionWidthInRawPixels)
             .ThenBy(e => e.RefreshRate);
     }


### PR DESCRIPTION
The fallback display mode selection in `GetBestDisplayMode()` had two bugs in `MinRefreshRateMatches`:

1. Wrong parameter: Passed `videoHeight - 3` (eg 2157 for 4K content) instead of `videoFrameRate` (eg 23.976). Since no display mode has a >1000 Hz refresh rate, the filter was always true - effectively a no-op.
3. Inverted comparison: Used `refreshRate > mode.RefreshRate` (keep modes slower than the video) instead of `mode.RefreshRate >= refreshRate` (keep modes at least as fast). This is inconsistent with the analogous `MinResolutionMatches` which correctly uses `>=`.

Together, these bugs cancelled each other out (the filter did nothing), so the fallback worked by accident via the subsequent `OrderBy`. The fix makes the filter express the correct constraint: keep display modes whose refresh rate can handle the video's frame rate.