### PR TITLE
Add explanatory comment for why console.debug is not forwarded to C# logger

### DIFF
--- a/Jellyfin/Resources/winuwp.js
+++ b/Jellyfin/Resources/winuwp.js
@@ -216,6 +216,8 @@ if (!window.consoleXboxOverride)
             window.chrome.webview.postMessage(JSON.stringify({ type: "log", args: { level: logLevel, messages: argsArray } }));
         }
     }
+    // debug is intentionally commented out as it can overwhelm the interopt layer. Uncomment for troubleshooting if needed.
+    //logOverride("debug");
     logOverride("error");
     logOverride("log");
     logOverride("warn");


### PR DESCRIPTION
[Original description below for historical preservation. See comments to explain current change]

The JavaScript log override hooks in `winuwp.js` forwarded `console.error`, `console.log`, `console.warn`, and `console.info` to the C# logger, but `console.debug` was missing. The C# `MessageHandler` already has a `case "debug"` handler mapping to `LogDebug`, so these messages were silently lost.

This change adds `logOverride("debug")` so debug-level messages from the webview are captured. These are filtered by the configured log level, so no log spam in normal operation.