### PR TITLE
Fix stack trace loss, BeginScope crash, and dead code

### DIFF
--- a/Jellyfin/Core/FileBackedLoggerProvider.cs
+++ b/Jellyfin/Core/FileBackedLoggerProvider.cs
@@ -139,7 +139,16 @@ internal sealed class FileBackedLoggerProvider : ILoggerProvider
         public IDisposable BeginScope<TState>(TState state)
             where TState : notnull
         {
-            throw new NotImplementedException();
+            return NullScope.Instance;
+        }
+
+        private sealed class NullScope : IDisposable
+        {
+            public static NullScope Instance { get; } = new NullScope();
+
+            public void Dispose()
+            {
+            }
         }
     }
 }

--- a/Jellyfin/Core/NativeShellScriptLoader.cs
+++ b/Jellyfin/Core/NativeShellScriptLoader.cs
@@ -6,7 +6,6 @@ using Jellyfin.Core.Contract;
 using Jellyfin.Utils;
 using Windows.Graphics.Display.Core;
 using Windows.Storage;
-using Windows.System.Profile;
 
 namespace Jellyfin.Core;
 
@@ -32,15 +31,7 @@ public class NativeShellScriptLoader : INativeShellScriptLoader
             Wrap(assembly.GetCustomAttribute<AssemblyTitleAttribute>().Title, '\''));
         nativeShellScript = nativeShellScript.Replace("APP_VERSION", Wrap(assembly.GetName().Version.ToString(), '\''));
 
-        var deviceForm = AnalyticsInfo.DeviceForm;
-        if (deviceForm == "Unknown")
-        {
-            deviceForm = AppUtils.GetDeviceFormFactorType().ToString();
-        }
-
-        deviceForm = DeviceFormFactorType.Xbox.ToString();
-
-        nativeShellScript = nativeShellScript.Replace("DEVICE_NAME", Wrap(deviceForm, '\''));
+        nativeShellScript = nativeShellScript.Replace("DEVICE_NAME", Wrap(DeviceFormFactorType.Xbox.ToString(), '\''));
 
         var hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
         if (hdmiDisplayInformation != null)

--- a/Jellyfin/Core/ServerDiscovery.cs
+++ b/Jellyfin/Core/ServerDiscovery.cs
@@ -142,7 +142,7 @@ public sealed class ServerDiscovery : IDisposable, IServerDiscovery
                         return;
                     default:
                         _logger.LogError(ex, $"Socket Error: {ex.Message}");
-                        throw ex;
+                        throw;
                 }
             }
         }


### PR DESCRIPTION
## Summary
- **ServerDiscovery**: change `throw ex` to `throw` to preserve the original stack trace when re-throwing SocketException
- **FileBackedLoggerProvider**: return a no-op `IDisposable` from `BeginScope` instead of throwing `NotImplementedException`, which would crash if any logging infrastructure called `BeginScope`
- **NativeShellScriptLoader**: remove dead device form detection code that was unconditionally overwritten on the next line

## Test plan
- [ ] Verify server discovery still works on local network
- [ ] Verify logging still functions (BeginScope no longer crashes)
- [ ] Verify NativeShell JS bridge still injects correctly with Xbox device name