### PR TITLE
Add network connectivity awareness and offline recovery

### DIFF
--- a/Jellyfin/Controls/JellyfinWebView.xaml
+++ b/Jellyfin/Controls/JellyfinWebView.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewModels="using:Jellyfin.ViewModels"
+    xmlns:triggers="using:CommunityToolkit.WinUI.Triggers"
     mc:Ignorable="d"
     d:DesignHeight="400"
     d:DesignWidth="800"
@@ -49,6 +50,27 @@
                   Background="{StaticResource OverlayColorBG}"
                   Visibility="{Binding IsInProgress, Converter={StaticResource BooleanVisibilityConverter}}">
                 <ProgressRing Width="250" Height="250" IsActive="True" Visibility="Visible" />
+            </Grid>
+
+            <Grid Grid.Row="0"
+                  Background="{StaticResource Color0}"
+                  Visibility="{Binding IsOffline, Converter={StaticResource BooleanVisibilityConverter}}">
+                <StackPanel HorizontalAlignment="Center"
+                            VerticalAlignment="Center"
+                            Spacing="16">
+                    <FontIcon Glyph="&#xF384;"
+                              FontSize="48"
+                              Foreground="{StaticResource Color80}"
+                              HorizontalAlignment="Center" />
+                    <TextBlock Text="No network connection"
+                               Foreground="{StaticResource Color90}"
+                               FontSize="{StaticResource FontL}"
+                               HorizontalAlignment="Center" />
+                    <TextBlock Text="Waiting for connection to resume..."
+                               Foreground="{StaticResource Color80}"
+                               FontSize="{StaticResource FontM}"
+                               HorizontalAlignment="Center" />
+                </StackPanel>
             </Grid>
         </Grid>
 

--- a/Jellyfin/ViewModels/JellyfinWebViewModel.cs
+++ b/Jellyfin/ViewModels/JellyfinWebViewModel.cs
@@ -79,6 +79,7 @@ public sealed class JellyfinWebViewModel : ObservableRecipient, IDisposable, IRe
         Central.Settings.JellyfinServerAccessToken = null;
         IsInProgress = true;
         Messenger.Register(this);
+        NetworkHelper.Instance.NetworkChanged += OnNetworkChanged;
 
         if (Central.Settings.JellyfinServerValidated)
         {
@@ -107,6 +108,15 @@ public sealed class JellyfinWebViewModel : ObservableRecipient, IDisposable, IRe
     {
         get => _isInProgress;
         set => SetProperty(ref _isInProgress, value);
+    }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the device is offline.
+    /// </summary>
+    public bool IsOffline
+    {
+        get => field;
+        set => SetProperty(ref field, value);
     }
 
     /// <summary>
@@ -433,6 +443,20 @@ public sealed class JellyfinWebViewModel : ObservableRecipient, IDisposable, IRe
         }
     }
 
+    private void OnNetworkChanged(object sender, EventArgs e)
+    {
+        _ = _dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+        {
+            var wasOffline = IsOffline;
+            IsOffline = !NetworkHelper.Instance.ConnectionInformation.IsInternetAvailable;
+            if (wasOffline && !IsOffline && WebView?.CoreWebView2 != null)
+            {
+                _logger.LogInformation("Network restored, reloading page.");
+                WebView.CoreWebView2.Reload();
+            }
+        });
+    }
+
     private void OnDisplayModeChanged(HdmiDisplayInformation sender, object args)
     {
         _ = Task.Run(async () =>
@@ -444,6 +468,7 @@ public sealed class JellyfinWebViewModel : ObservableRecipient, IDisposable, IRe
     /// <inheritdoc />
     public void Dispose()
     {
+        NetworkHelper.Instance.NetworkChanged -= OnNetworkChanged;
         _navigationHandler.Dispose();
         _weakPropertyChangedListener.Detach();
         UninitializeWebView();

--- a/Jellyfin/Views/OnBoarding.xaml
+++ b/Jellyfin/Views/OnBoarding.xaml
@@ -11,6 +11,7 @@
     xmlns:winui="using:CommunityToolkit.WinUI"
     xmlns:behaviors="using:Jellyfin.Behaviors"
     xmlns:localize="using:Jellyfin.Helpers.MarkupExtensions"
+    xmlns:triggers="using:CommunityToolkit.WinUI.Triggers"
     mc:Ignorable="d"
     d:DataContext="{d:DesignInstance viewModels:OnBoardingViewModel}">
 
@@ -24,6 +25,16 @@
                     <VisualState.Setters>
                         <Setter Target="EmptyServersMessage.Visibility" Value="Visible"/>
                         <Setter Target="TopBarDiscoveryProgress.Visibility" Value="Collapsed"/>
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+            <VisualStateGroup x:Name="ConnectivityStates">
+                <VisualState x:Name="OfflineState">
+                    <VisualState.StateTriggers>
+                        <triggers:NetworkConnectionStateTrigger ConnectionState="Disconnected" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Target="OfflineBanner.Visibility" Value="Visible"/>
                     </VisualState.Setters>
                 </VisualState>
             </VisualStateGroup>
@@ -218,6 +229,33 @@
                 </ListView>
             </StackPanel>
         </Grid>
+
+        <Border x:Name="OfflineBanner"
+                Grid.Row="0"
+                Grid.RowSpan="2"
+                Grid.ColumnSpan="2"
+                Background="{StaticResource Color0}"
+                Visibility="Collapsed"
+                Padding="0,20,0,0">
+            <StackPanel HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        Spacing="8">
+                <FontIcon Glyph="&#xF384;"
+                          FontSize="48"
+                          Foreground="{StaticResource Color80}"
+                          HorizontalAlignment="Center" />
+                <TextBlock Text="No network connection"
+                           Foreground="{StaticResource Color90}"
+                           FontSize="{StaticResource FontL}"
+                           FontFamily="{StaticResource JellyfinFamilyFont}"
+                           HorizontalAlignment="Center" />
+                <TextBlock Text="Please check your network settings and try again."
+                           Foreground="{StaticResource Color80}"
+                           FontSize="{StaticResource FontM}"
+                           FontFamily="{StaticResource JellyfinFamilyFont}"
+                           HorizontalAlignment="Center" />
+            </StackPanel>
+        </Border>
 
         <Grid Grid.Row="0"
                     Grid.RowSpan="2"


### PR DESCRIPTION
## Summary
- Detect network disconnection using `NetworkHelper` from CommunityToolkit (already a dependency) and show a user-friendly offline overlay instead of leaving WebView2 on a dead error page
- Auto-reload the page when connectivity is restored
- On the OnBoarding page, use `NetworkConnectionStateTrigger` to show an offline banner when disconnected, preventing connection attempts that would fail

## Test plan
- [ ] Disconnect network while viewing media library — verify offline overlay appears
- [ ] Reconnect network — verify page auto-reloads
- [ ] Open OnBoarding page with no network — verify offline banner shows
- [ ] Reconnect on OnBoarding — verify banner hides and server discovery resumes