### PR TITLE
Fix HttpClient socket exhaustion anti-pattern

### DIFF
--- a/Jellyfin/App.xaml.cs
+++ b/Jellyfin/App.xaml.cs
@@ -32,6 +32,11 @@ namespace Jellyfin;
 /// </summary>
 public sealed partial class App : Application
 {
+    private static readonly HttpClient LogUploadHttpClient = new HttpClient
+    {
+        Timeout = TimeSpan.FromSeconds(30)
+    };
+
     private static bool _layoutScalingDisabled;
 
     /// <summary>
@@ -151,16 +156,18 @@ public sealed partial class App : Application
     {
         try
         {
-            using var httpClient = new HttpClient();
-            httpClient.Timeout = TimeSpan.FromSeconds(30);
-            httpClient.DefaultRequestHeaders.Add("X-Emby-Token", Central.Settings.JellyfinServerAccessToken);
-            httpClient.BaseAddress = new Uri(Central.Settings.JellyfinServer);
             var loggerProvider = (FileBackedLoggerProvider)Services.GetRequiredService<ILoggerProvider>();
             using var logStream = await loggerProvider.ReadLogfile(logfileName).ConfigureAwait(false);
-            using var response = await httpClient.PostAsync("/ClientLog/Document", new StreamContent(logStream)).ConfigureAwait(false);
+            var uploadUri = new Uri(new Uri(Central.Settings.JellyfinServer), "/ClientLog/Document");
+            using var request = new HttpRequestMessage(HttpMethod.Post, uploadUri)
+            {
+                Content = new StreamContent(logStream)
+            };
+            request.Headers.Add("X-Emby-Token", Central.Settings.JellyfinServerAccessToken);
+            using var response = await LogUploadHttpClient.SendAsync(request).ConfigureAwait(false);
             return response.StatusCode == System.Net.HttpStatusCode.OK;
         }
-        catch
+        catch (Exception)
         {
             // really no point in logging here, the log will never show up anywhere.
             return false;

--- a/Jellyfin/Utils/ServerCheckUtil.cs
+++ b/Jellyfin/Utils/ServerCheckUtil.cs
@@ -15,6 +15,11 @@ public static class ServerCheckUtil
     private const string ApiSystemInfoRoute = "/System/Info/Public";
     private const string ValidProductName = "Jellyfin Server";
 
+    private static readonly HttpClient HttpClient = new HttpClient
+    {
+        Timeout = TimeSpan.FromSeconds(10)
+    };
+
     /// <summary>
     /// Gets or sets a value indicating whether the server version is unsupported in the future by this client version.
     /// </summary>
@@ -30,13 +35,8 @@ public static class ServerCheckUtil
     {
         try
         {
-            using var httpClient = new HttpClient
-            {
-                Timeout = TimeSpan.FromSeconds(10)
-            };
-
             using var headRequest = new HttpRequestMessage(HttpMethod.Head, serverUri);
-            using var headResponse = await httpClient.SendAsync(headRequest).ConfigureAwait(true);
+            using var headResponse = await HttpClient.SendAsync(headRequest).ConfigureAwait(true);
             var finalUri = headResponse.RequestMessage.RequestUri;
 
             // Jellyfin redirects to a web root path, which is not a valid base path for the API.
@@ -48,7 +48,7 @@ public static class ServerCheckUtil
 
             var infoUri = new Uri(basePath + ApiSystemInfoRoute);
 
-            using var response = await httpClient.GetAsync(infoUri).ConfigureAwait(true);
+            using var response = await HttpClient.GetAsync(infoUri).ConfigureAwait(true);
 
             if (!response.IsSuccessStatusCode)
             {


### PR DESCRIPTION
## Summary
- Replace per-call `new HttpClient()` with shared static instances to prevent socket exhaustion from repeated create/dispose cycles
- **ServerCheckUtil**: use a static `HttpClient` with 10s timeout
- **App.UploadClientLog**: use a static `HttpClient` with 30s timeout and per-request headers via `HttpRequestMessage` instead of mutating `DefaultRequestHeaders`

## Test plan
- [ ] Verify server validation still works during onboarding (multiple URL variants tested)
- [ ] Verify log upload from Settings page still works
- [ ] Verify crash dialog log upload still works