### PR TITLE
Fix DiscoveredServer equality contract and null safety

### DIFF
--- a/Jellyfin/Models/DiscoveredServer.cs
+++ b/Jellyfin/Models/DiscoveredServer.cs
@@ -3,7 +3,7 @@ using System;
 namespace Jellyfin.Models;
 
 /// <summary>
-/// Reperesents the server metadata provided by JellyfinServer after autodiscover.
+/// Represents the server metadata provided by JellyfinServer after autodiscover.
 /// </summary>
 public class DiscoveredServer : IComparable<DiscoveredServer>, IEquatable<DiscoveredServer>
 {
@@ -30,12 +30,34 @@ public class DiscoveredServer : IComparable<DiscoveredServer>, IEquatable<Discov
     /// <inheritdoc/>
     public int CompareTo(DiscoveredServer other)
     {
-        return Id.CompareTo(other.Id);
+        if (other is null)
+        {
+            return 1;
+        }
+
+        return string.Compare(Id, other.Id, StringComparison.Ordinal);
     }
 
     /// <inheritdoc/>
     public bool Equals(DiscoveredServer other)
     {
-        return Id.Equals(other.Id);
+        if (other is null)
+        {
+            return false;
+        }
+
+        return string.Equals(Id, other.Id, StringComparison.Ordinal);
+    }
+
+    /// <inheritdoc/>
+    public override bool Equals(object obj)
+    {
+        return Equals(obj as DiscoveredServer);
+    }
+
+    /// <inheritdoc/>
+    public override int GetHashCode()
+    {
+        return Id != null ? StringComparer.Ordinal.GetHashCode(Id) : 0;
     }
 }


### PR DESCRIPTION
## Summary
- Override `GetHashCode` to match `IEquatable<T>` contract (equal objects must have equal hash codes)
- Override `object.Equals` to delegate to typed `Equals`
- Add null checks to `Equals` and `CompareTo` to prevent `NullReferenceException`
- Use `StringComparison.Ordinal` for consistent string comparison
- Fix typo in XML doc: "Reperesents" → "Represents"

## Test plan
- [ ] Verify server auto-discovery still populates the list without duplicates
- [ ] Verify clicking a discovered server still navigates to it