### PR TITLE
Localize hard-coded strings in Settings and deprecation notice

### DIFF
--- a/Jellyfin/Controls/JellyfinWebView.xaml
+++ b/Jellyfin/Controls/JellyfinWebView.xaml
@@ -5,6 +5,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:viewModels="using:Jellyfin.ViewModels"
+    xmlns:localize="using:Jellyfin.Helpers.MarkupExtensions"
     mc:Ignorable="d"
     d:DesignHeight="400"
     d:DesignWidth="800"
@@ -68,9 +69,9 @@
                        Padding="8"
                        HorizontalTextAlignment="Center"
                        Foreground="{StaticResource DangerColor}">
-                This version of Jellyfin-for-xbox will soon be deprecated. <LineBreak />
-                Please update the Jellyfin Server to 10.11 when it's released. <LineBreak />
-                Shortly after the official 10.11 release the next version of this client will not be compatible.
+                <Run Text="{localize:Localize Key=WebView.DeprecationNotice.Line1}" /> <LineBreak />
+                <Run Text="{localize:Localize Key=WebView.DeprecationNotice.Line2}" /> <LineBreak />
+                <Run Text="{localize:Localize Key=WebView.DeprecationNotice.Line3}" />
             </TextBlock>
         </Border>
     </Grid>

--- a/Jellyfin/Resources/en-US/Translations.resw
+++ b/Jellyfin/Resources/en-US/Translations.resw
@@ -254,4 +254,34 @@ You might encounter bugs when running on a PC.</value>
     <data name="Settings.Logs.Title" xml:space="preserve">
     <value>Logfiles</value>
   </data>
+  <data name="Settings.Display.Label" xml:space="preserve">
+    <value>Display:</value>
+  </data>
+  <data name="Settings.ColorSpace.Label" xml:space="preserve">
+    <value>Color Space:</value>
+  </data>
+  <data name="Settings.Hdr10.Label" xml:space="preserve">
+    <value>HDR 10:</value>
+  </data>
+  <data name="Settings.DolbyVisionLowLatency.Label" xml:space="preserve">
+    <value>DV Low Latency:</value>
+  </data>
+  <data name="Settings.Smpte.Label" xml:space="preserve">
+    <value>SMPTE:</value>
+  </data>
+  <data name="Settings.AvailableDisplay.Label" xml:space="preserve">
+    <value>Available Display:</value>
+  </data>
+  <data name="Settings.Fps.Label" xml:space="preserve">
+    <value>Fps</value>
+  </data>
+  <data name="WebView.DeprecationNotice.Line1" xml:space="preserve">
+    <value>This version of Jellyfin-for-Xbox will soon be deprecated.</value>
+  </data>
+  <data name="WebView.DeprecationNotice.Line2" xml:space="preserve">
+    <value>Please update the Jellyfin Server to 10.11 when it's released.</value>
+  </data>
+  <data name="WebView.DeprecationNotice.Line3" xml:space="preserve">
+    <value>Shortly after the official 10.11 release the next version of this client will not be compatible.</value>
+  </data>
 </root>

--- a/Jellyfin/Views/Settings.xaml
+++ b/Jellyfin/Views/Settings.xaml
@@ -209,7 +209,7 @@
                             <TextBlock Text="{Binding ResolutionWidthInRawPixels}" />
                             <TextBlock Text="-" Margin="5,0,5,0" />
                             <TextBlock Text="{Binding RefreshRate}" />
-                            <TextBlock Text="Fps" Margin="5,0,5,0" />
+                            <TextBlock Text="{localize:Localize Key=Settings.Fps.Label}" Margin="5,0,5,0" />
                         </StackPanel>
                     </DataTemplate>
                 </Grid.Resources>
@@ -241,7 +241,7 @@
                 <TextBlock
                     Grid.Row="1"
                     Grid.Column="0"
-                    Text="Display: " />
+                    Text="{localize:Localize Key=Settings.Display.Label}" />
                 <StackPanel
                     Orientation="Horizontal"
                     Grid.Row="1"
@@ -253,7 +253,7 @@
                 <TextBlock
                     Grid.Row="2"
                     Grid.Column="0"
-                    Text="Color Space: " />
+                    Text="{localize:Localize Key=Settings.ColorSpace.Label}" />
                 <TextBlock
                     Grid.Row="2"
                     Grid.Column="1"
@@ -262,7 +262,7 @@
                 <TextBlock
                     Grid.Row="3"
                     Grid.Column="0"
-                    Text="HDR 10: " />
+                    Text="{localize:Localize Key=Settings.Hdr10.Label}" />
                 <TextBlock
                     Grid.Row="3"
                     Grid.Column="1"
@@ -271,7 +271,7 @@
                 <TextBlock
                     Grid.Row="4"
                     Grid.Column="0"
-                    Text="DV Low Latency: " />
+                    Text="{localize:Localize Key=Settings.DolbyVisionLowLatency.Label}" />
                 <TextBlock
                     Grid.Row="4"
                     Grid.Column="1"
@@ -280,7 +280,7 @@
                 <TextBlock
                     Grid.Row="5"
                     Grid.Column="0"
-                    Text="SMTPE: " />
+                    Text="{localize:Localize Key=Settings.Smpte.Label}" />
                 <TextBlock
                     Grid.Row="5"
                     Grid.Column="1"
@@ -289,7 +289,7 @@
                 <TextBlock
                     Grid.Row="6"
                     Grid.Column="0"
-                    Text="Available Display: " />
+                    Text="{localize:Localize Key=Settings.AvailableDisplay.Label}" />
                 <ItemsControl
                     Grid.Row="6"
                     Grid.Column="1"


### PR DESCRIPTION
## Summary
- Replace hard-coded English strings with localization bindings in Settings.xaml: Display, Color Space, HDR 10, DV Low Latency, Available Display, and Fps labels
- Fix "SMTPE" typo → "SMPTE" via the new localization key
- Move hard-coded deprecation notice text in JellyfinWebView.xaml to resource file
- Add corresponding en-US resource entries for all new keys

## Test plan
- [ ] Verify Settings page renders all labels correctly in English
- [ ] Verify deprecation notice displays correctly (if server triggers it)
- [ ] Verify no XAML binding errors in debug output