### PR TITLE
Fix HDMI display mode matching and add logging

### DIFF
--- a/Jellyfin/Core/FullScreenManager.cs
+++ b/Jellyfin/Core/FullScreenManager.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Jellyfin.Core.Contract;
 using Jellyfin.Utils;
+using Microsoft.Extensions.Logging;
 using Windows.Data.Json;
 using Windows.Graphics.Display.Core;
 using Windows.System.Display;
@@ -21,6 +21,7 @@ public sealed class FullScreenManager : IFullScreenManager
     private readonly ApplicationView _applicationView;
     private readonly Frame _frame;
     private readonly DisplayRequest _displayRequest;
+    private readonly ILogger<FullScreenManager> _logger;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FullScreenManager"/> class.
@@ -28,11 +29,13 @@ public sealed class FullScreenManager : IFullScreenManager
     /// <param name="applicationView">The <see cref="ApplicationView"/> instance used to manage the application's view state.</param>
     /// <param name="frame">The root frame.</param>
     /// <param name="displayRequest">The display Request.</param>
-    public FullScreenManager(ApplicationView applicationView, Frame frame, DisplayRequest displayRequest)
+    /// <param name="logger">The logger.</param>
+    public FullScreenManager(ApplicationView applicationView, Frame frame, DisplayRequest displayRequest, ILogger<FullScreenManager> logger)
     {
         _applicationView = applicationView;
         _frame = frame;
         _displayRequest = displayRequest;
+        _logger = logger;
     }
 
     private async Task SwitchToBestDisplayMode(uint videoWidth, uint videoHeight, double videoFrameRate, HdmiDisplayHdrOption hdmiDisplayHdrOption)
@@ -48,6 +51,8 @@ public sealed class FullScreenManager : IFullScreenManager
                 if (await hdmiDisplayInformation
                     ?.RequestSetCurrentDisplayModeAsync(item))
                 {
+                    _logger.LogInformation("Switched display mode to {Width}x{Height} @ {RefreshRate}Hz, HDR: {HdrOption}",
+                        item.ResolutionWidthInRawPixels, item.ResolutionHeightInRawPixels, item.RefreshRate, hdmiDisplayHdrOption);
                     return;
                 }
             }
@@ -104,7 +109,7 @@ public sealed class FullScreenManager : IFullScreenManager
 
     private static Func<HdmiDisplayMode, bool> ResolutionMatches(uint width, uint height)
     {
-        return mode => mode.ResolutionWidthInRawPixels == width || mode.ResolutionHeightInRawPixels == height;
+        return mode => mode.ResolutionWidthInRawPixels == width && mode.ResolutionHeightInRawPixels == height;
     }
 
     private static Func<HdmiDisplayMode, bool> MinResolutionMatches(uint width, uint height)
@@ -182,12 +187,12 @@ public sealed class FullScreenManager : IFullScreenManager
                 }
                 catch (Exception ex)
                 {
-                    Debug.WriteLine("Error during SwitchToBestDisplayMode", ex);
+                    _logger.LogError(ex, "Error during SwitchToBestDisplayMode");
                 }
             }
             else
             {
-                Debug.WriteLine("enableFullscreenAsync called with no args");
+                _logger.LogDebug("enableFullscreenAsync called with no args");
             }
         }
         else

--- a/Jellyfin/Resources/winuwp.js
+++ b/Jellyfin/Resources/winuwp.js
@@ -198,7 +198,9 @@ class UwpXboxHdmiSetupPlugin {
             };
 
             window.chrome.webview.postMessage(JSON.stringify(payload));
-            await new Promise(resolve => setTimeout(resolve, 3000)); // wait 3 sec before continuing with playback to setup display
+            // Allow time for TV to complete HDMI display mode switch before starting playback.
+            // Some displays may take longer; ideally this would wait for a completion signal.
+            await new Promise(resolve => setTimeout(resolve, 3000));
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix `ResolutionMatches` to use AND logic instead of OR for exact resolution matching, preventing incorrect partial matches (e.g. 1920x1080 matching a 3840x1080 mode)
- Add `ILogger` to `FullScreenManager` for display mode switch diagnostics
- Log selected display mode parameters (resolution, refresh rate, HDR option) on successful switch
- Replace `Debug.WriteLine` with structured logging
- Add descriptive comment about the 3-second HDMI switch delay in winuwp.js

## Test plan
- [ ] Play content at various resolutions (1080p, 4K) and verify correct display mode is selected
- [ ] Play HDR content and verify HDR mode is activated
- [ ] Check log output for display mode switch entries
- [ ] Verify the DI container resolves FullScreenManager with the new ILogger parameter