### PR TITLE
Improve logging quality and message handling

### DIFF
--- a/Jellyfin/Core/FileBackedLoggerProvider.cs
+++ b/Jellyfin/Core/FileBackedLoggerProvider.cs
@@ -19,7 +19,7 @@ internal sealed class FileBackedLoggerProvider : ILoggerProvider
 
     public FileBackedLoggerProvider()
     {
-        _localLogFilePath = $"jellyfin-for-xbox-{DateTime.Now:yyyy-MM-dd-HH-mm-ss}";
+        _localLogFilePath = $"jellyfin-for-xbox-{DateTime.UtcNow:yyyy-MM-dd-HH-mm-ss}";
         _logPipe = Channel.CreateUnbounded<string>(
             new UnboundedChannelOptions
             {
@@ -126,7 +126,7 @@ internal sealed class FileBackedLoggerProvider : ILoggerProvider
             }
 
             var message = formatter(state, exception);
-            var logEntry = $"{DateTime.Now:s} [{logLevel}] {message}\n";
+            var logEntry = $"{DateTime.UtcNow:s} [{logLevel}] {message}\n";
 
             _appLoggerProvider._logPipe.Writer.TryWrite(logEntry);
         }

--- a/Jellyfin/Core/MessageHandler.cs
+++ b/Jellyfin/Core/MessageHandler.cs
@@ -48,81 +48,75 @@ public class MessageHandler : IMessageHandler
         var eventType = json.GetNamedString("type");
         var args = json.GetNamedObject("args");
 
-        if (eventType == "enableFullscreen")
+        switch (eventType)
         {
-            _ = _frame.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
-            {
-                await _fullScreenManager.EnableFullscreenAsync(args).ConfigureAwait(true);
-            });
-        }
-        else if (eventType == "disableFullscreen")
-        {
-            await _fullScreenManager.DisableFullScreen().ConfigureAwait(true);
-        }
-        else if (eventType == "selectServer")
-        {
-            Central.Settings.JellyfinServer = null;
-            _ = _frame.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-            {
-                _frame.Navigate(typeof(OnBoarding));
-            });
-        }
-        else if (eventType == "openClientSettings")
-        {
-            _ = _frame.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
-            {
-                var settingsPopup = new Popup()
+            case "enableFullscreen":
+                _ = _frame.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, async () =>
                 {
-                    HorizontalOffset = 0,
-                    VerticalOffset = 0,
-                    Width = Window.Current.Bounds.Width,
-                    Height = Window.Current.Bounds.Height,
-                };
-                settingsPopup.Child = new Settings()
+                    await _fullScreenManager.EnableFullscreenAsync(args).ConfigureAwait(true);
+                });
+                break;
+            case "disableFullscreen":
+                await _fullScreenManager.DisableFullScreen().ConfigureAwait(true);
+                break;
+            case "selectServer":
+                Central.Settings.JellyfinServer = null;
+                _ = _frame.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
                 {
-                    ParentPopup = settingsPopup,
-                    Width = Window.Current.Bounds.Width,
-                    Height = Window.Current.Bounds.Height,
-                };
-                settingsPopup.IsOpen = true;
-                (settingsPopup.Child as Control).Focus(FocusState.Programmatic);
-            });
-        }
-        else if (eventType == "exit")
-        {
-            Exit();
-        }
-        else if (eventType == "loaded")
-        {
-            _messenger.Send(new WebMessage(eventType, args));
-        }
-        else if (eventType == "log")
-        {
-            var level = args.GetNamedString("level");
-            switch (level)
-            {
-                case "debug":
-                    _webviewLogger.LogDebug(args.GetNamedValue("messages").ToString());
-                    break;
-                case "error":
-                    _webviewLogger.LogError(args.GetNamedValue("messages").ToString());
-                    break;
-                case "warn":
-                    _webviewLogger.LogWarning(args.GetNamedValue("messages").ToString());
-                    break;
-                case "info" or "log":
-                    _webviewLogger.LogInformation(args.GetNamedValue("messages").ToString());
-                    break;
-                default:
-                    break;
-            }
-        }
-        else
-        {
-            Debug.WriteLine($"Unexpected JSON message: {eventType}");
-        }
+                    _frame.Navigate(typeof(OnBoarding));
+                });
+                break;
+            case "openClientSettings":
+                _ = _frame.Dispatcher.RunAsync(CoreDispatcherPriority.Normal, () =>
+                {
+                    var settingsPopup = new Popup()
+                    {
+                        HorizontalOffset = 0,
+                        VerticalOffset = 0,
+                        Width = Window.Current.Bounds.Width,
+                        Height = Window.Current.Bounds.Height,
+                    };
+                    settingsPopup.Child = new Settings()
+                    {
+                        ParentPopup = settingsPopup,
+                        Width = Window.Current.Bounds.Width,
+                        Height = Window.Current.Bounds.Height,
+                    };
+                    settingsPopup.IsOpen = true;
+                    (settingsPopup.Child as Control).Focus(FocusState.Programmatic);
+                });
+                break;
+            case "exit":
+                Exit();
+                break;
+            case "loaded":
+                _messenger.Send(new WebMessage(eventType, args));
+                break;
+            case "log":
+                var level = args.GetNamedString("level");
+                switch (level)
+                {
+                    case "debug":
+                        _webviewLogger.LogDebug(args.GetNamedValue("messages").ToString());
+                        break;
+                    case "error":
+                        _webviewLogger.LogError(args.GetNamedValue("messages").ToString());
+                        break;
+                    case "warn":
+                        _webviewLogger.LogWarning(args.GetNamedValue("messages").ToString());
+                        break;
+                    case "info" or "log":
+                        _webviewLogger.LogInformation(args.GetNamedValue("messages").ToString());
+                        break;
+                    default:
+                        break;
+                }
 
-        await Task.CompletedTask.ConfigureAwait(true);
+                break;
+            default:
+                Debug.WriteLine($"Unexpected JSON message: {eventType}");
+                break;
+        }
     }
 
     private void Exit()

--- a/Jellyfin/Core/ServerDiscovery.cs
+++ b/Jellyfin/Core/ServerDiscovery.cs
@@ -101,7 +101,7 @@ public sealed class ServerDiscovery : IDisposable, IServerDiscovery
         }
         catch (SocketException ex)
         {
-            _logger.LogError(ex, $"Broadcast errored with message: {ex.Message}");
+            _logger.LogError(ex, "Broadcast error.");
         }
     }
 
@@ -119,7 +119,7 @@ public sealed class ServerDiscovery : IDisposable, IServerDiscovery
                 }
 
                 var text = Encoding.ASCII.GetString(dataReceived);
-                _logger.LogDebug($"Server discovery Received: {text}");
+                _logger.LogDebug("Server discovery received: {Text}", text);
 
                 var discoveredServer = JsonSerializer.Deserialize<DiscoveredServer>(text);
                 OnDiscover?.Invoke(discoveredServer);
@@ -134,14 +134,14 @@ public sealed class ServerDiscovery : IDisposable, IServerDiscovery
                 switch (ex.SocketErrorCode)
                 {
                     case SocketError.TimedOut:
-                        _logger.LogDebug(ex, $"Socket Timed out");
+                        _logger.LogDebug(ex, "Socket timed out.");
                         break;
                     case SocketError.Interrupted:
                         // Socket disposed
                         _logger.LogError(ex, "Socket interrupted.");
                         return;
                     default:
-                        _logger.LogError(ex, $"Socket Error: {ex.Message}");
+                        _logger.LogError(ex, "Socket error.");
                         throw ex;
                 }
             }


### PR DESCRIPTION
## Summary
- **MessageHandler**: replace if-else chain with switch statement for readability, remove redundant `await Task.CompletedTask`
- **ServerDiscovery**: use structured logging templates instead of string interpolation to enable log aggregation
- **FileBackedLoggerProvider**: use `DateTime.UtcNow` for consistent timestamps across timezones

## Test plan
- [ ] Verify all message types still handled (fullscreen, exit, settings, etc.)
- [ ] Verify log files contain UTC timestamps
- [ ] Verify server discovery still logs correctly