### PR TITLE
Improve OnBoarding page error messaging

### DIFF
--- a/Jellyfin/Resources/en-US/Translations.resw
+++ b/Jellyfin/Resources/en-US/Translations.resw
@@ -156,7 +156,10 @@ You might encounter bugs when running on a PC.</value>
     <value>Connect to Jellyfin Server.</value>
   </data>
   <data name="OnBoarding.ServerDiscovery.Empty.Text" xml:space="preserve">
-    <value>No local servers found.</value>
+    <value>No servers found on your local network. You can still connect manually by entering the server address.</value>
+  </data>
+  <data name="OnBoarding.ConnectionError.Hint.Text" xml:space="preserve">
+    <value>Make sure your Jellyfin server is running and reachable on this network.</value>
   </data>
   <data name="OnBoarding.ServerDiscovery.Header.Text" xml:space="preserve">
     <value>Local Servers.</value>

--- a/Jellyfin/Views/OnBoarding.xaml
+++ b/Jellyfin/Views/OnBoarding.xaml
@@ -152,6 +152,15 @@
                                 FontSize="{StaticResource FontM}"
                                 Margin="1 1 1 20" />
 
+                    <TextBlock Text="{localize:Localize Key=OnBoarding.ConnectionError.Hint.Text}"
+                               Foreground="{StaticResource Color80}"
+                               FontFamily="{StaticResource JellyfinFamilyFont}"
+                               FontSize="{StaticResource FontS}"
+                               TextWrapping="Wrap"
+                               HorizontalAlignment="Center"
+                               TextAlignment="Center"
+                               Margin="0 0 0 16" />
+
                     <TextBlock Text="{localize:Localize Key=OnBoarding.ServerList.Error.Text}" Foreground="White"/>
                     <ItemsControl ItemsSource="{Binding TestedUris}">
                         <ItemsControl.ItemTemplate>


### PR DESCRIPTION
## Summary
- Make server discovery empty state more helpful: tell users they can still connect manually by entering the address
- Add actionable hint below connection errors suggesting to check that the server is running and reachable on the network

## Test plan
- [ ] Open OnBoarding with no local servers — verify improved empty state message
- [ ] Enter an invalid server URL — verify error shows with helpful hint text
- [ ] Verify existing connection flow still works for valid servers