### PR TITLE
Fix null-safety issues in FullScreenManager

### DIFF
--- a/Jellyfin/Core/FullScreenManager.cs
+++ b/Jellyfin/Core/FullScreenManager.cs
@@ -46,7 +46,7 @@ public sealed class FullScreenManager : IFullScreenManager
             foreach (var item in bestDisplayMode)
             {
                 if (await hdmiDisplayInformation
-                    ?.RequestSetCurrentDisplayModeAsync(item))
+                    .RequestSetCurrentDisplayModeAsync(item))
                 {
                     return;
                 }
@@ -154,7 +154,11 @@ public sealed class FullScreenManager : IFullScreenManager
 
     private async Task SetDefaultDisplayModeAsync()
     {
-        await HdmiDisplayInformation.GetForCurrentView()?.SetDefaultDisplayModeAsync();
+        var hdmiInfo = HdmiDisplayInformation.GetForCurrentView();
+        if (hdmiInfo != null)
+        {
+            await hdmiInfo.SetDefaultDisplayModeAsync();
+        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Remove misleading null-conditional operator on `hdmiDisplayInformation` which could not be null at that point in the code
- Fix `SetDefaultDisplayModeAsync` to properly null-check the return value of `GetForCurrentView()` instead of using `?.` which would cause `await null` to throw `NullReferenceException`

## Test plan
- [ ] Verify fullscreen video playback on Xbox triggers HDMI mode switch
- [ ] Verify exiting fullscreen restores default display mode
- [ ] Verify desktop fullscreen toggle still works