### PR TITLE
Report HDR10+ unsupported in device profile

### DIFF
--- a/Jellyfin/Core/FullScreenManager.cs
+++ b/Jellyfin/Core/FullScreenManager.cs
@@ -82,6 +82,8 @@ public sealed class FullScreenManager : IFullScreenManager
             case "HDR":
             case "HDR10":
             case "HDR10Plus":
+                // Xbox does not support HDR10+ dynamic metadata; falls back to static HDR10 (SMPTE 2084)
+                return hdrOtherwiseSdr;
             case "HLG":
                 return hdrOtherwiseSdr;
             case "DOVIWithSDR":

--- a/Jellyfin/Resources/winuwp.js
+++ b/Jellyfin/Resources/winuwp.js
@@ -97,6 +97,7 @@
                 if (supportsDolbyVision != null) {
                     options.supportsDolbyVision = supportsDolbyVision;
                 }
+                options.supportsHdr10Plus = false;
                 if (xboxSeries) {
                     options.maxVideoWidth = 3840;
                 }


### PR DESCRIPTION
## Summary
- Add `supportsHdr10Plus: false` to the device profile sent to the Jellyfin server so it can decide whether to transcode HDR10+ content rather than attempting direct play with unsupported dynamic metadata on Xbox
- Document the HDR10+ fallback behavior in FullScreenManager

## Test plan
- [ ] Verify HDR10 content still plays with correct HDMI mode
- [ ] Verify Dolby Vision content still plays correctly
- [ ] If HDR10+ content is available, verify server transcodes or falls back to HDR10