### PR TITLE
Minor code cleanup across multiple files

### DIFF
--- a/Jellyfin/App.xaml.cs
+++ b/Jellyfin/App.xaml.cs
@@ -160,7 +160,7 @@ public sealed partial class App : Application
             using var response = await httpClient.PostAsync("/ClientLog/Document", new StreamContent(logStream)).ConfigureAwait(false);
             return response.StatusCode == System.Net.HttpStatusCode.OK;
         }
-        catch
+        catch (Exception)
         {
             // really no point in logging here, the log will never show up anywhere.
             return false;

--- a/Jellyfin/Core/Central.cs
+++ b/Jellyfin/Core/Central.cs
@@ -19,7 +19,7 @@ public static class Central
     public static Version MinimumSupportedServerVersion { get; } = new(10, 11, 0);
 
     /// <summary>
-    /// Gets the minimum supported Jellyfin server version supported on this client.
+    /// Gets the minimum Jellyfin server version that will be supported by the next client release.
     /// </summary>
     public static Version MinimumFutureSupportedServerVersion { get; } = new(10, 11, 0);
 

--- a/Jellyfin/Core/SettingsManager.cs
+++ b/Jellyfin/Core/SettingsManager.cs
@@ -9,12 +9,12 @@ namespace Jellyfin.Core;
 /// </summary>
 public class SettingsManager : ISettingsManager
 {
-    private string _containerSettings = "APPSETTINGS";
-    private string _settingsServer = "SERVER";
-    private string _settingsServerVersion = "SERVER_VERSION";
-    private string _autoResolution = "AUTO_RESOLUTION";
-    private string _autoRefreshRate = "AUTO_REFRESH_RATE";
-    private string _forceEnableTvMode = "FORCE_TV_MODE";
+    private const string ContainerSettingsKey = "APPSETTINGS";
+    private const string SettingsServerKey = "SERVER";
+    private const string SettingsServerVersionKey = "SERVER_VERSION";
+    private const string AutoResolutionKey = "AUTO_RESOLUTION";
+    private const string AutoRefreshRateKey = "AUTO_REFRESH_RATE";
+    private const string ForceEnableTvModeKey = "FORCE_TV_MODE";
 
     private ApplicationDataContainer LocalSettings => ApplicationData.Current.LocalSettings;
 
@@ -22,12 +22,12 @@ public class SettingsManager : ISettingsManager
     {
         get
         {
-            if (!LocalSettings.Containers.ContainsKey(_containerSettings))
+            if (!LocalSettings.Containers.ContainsKey(ContainerSettingsKey))
             {
-                LocalSettings.CreateContainer(_containerSettings, ApplicationDataCreateDisposition.Always);
+                LocalSettings.CreateContainer(ContainerSettingsKey, ApplicationDataCreateDisposition.Always);
             }
 
-            return LocalSettings.Containers[_containerSettings];
+            return LocalSettings.Containers[ContainerSettingsKey];
         }
     }
 
@@ -41,8 +41,8 @@ public class SettingsManager : ISettingsManager
     /// </summary>
     public string JellyfinServer
     {
-        get => GetProperty<string>(_settingsServer);
-        set => SetProperty(_settingsServer, value);
+        get => GetProperty<string>(SettingsServerKey);
+        set => SetProperty(SettingsServerKey, value);
     }
 
     /// <summary>
@@ -52,7 +52,7 @@ public class SettingsManager : ISettingsManager
     {
         get
         {
-            var versionString = GetProperty<string>(_settingsServerVersion);
+            var versionString = GetProperty<string>(SettingsServerVersionKey);
             if (Version.TryParse(versionString, out var version))
             {
                 return version;
@@ -60,7 +60,7 @@ public class SettingsManager : ISettingsManager
 
             return null;
         }
-        set => SetProperty(_settingsServerVersion, value.ToString());
+        set => SetProperty(SettingsServerVersionKey, value.ToString());
     }
 
     /// <summary>
@@ -78,8 +78,8 @@ public class SettingsManager : ISettingsManager
     /// </summary>
     public bool AutoResolution
     {
-        get => GetProperty<bool>(_autoResolution);
-        set => SetProperty(_autoResolution, value);
+        get => GetProperty<bool>(AutoResolutionKey);
+        set => SetProperty(AutoResolutionKey, value);
     }
 
     /// <summary>
@@ -87,8 +87,8 @@ public class SettingsManager : ISettingsManager
     /// </summary>
     public bool AutoRefreshRate
     {
-        get => GetProperty<bool>(_autoRefreshRate);
-        set => SetProperty(_autoRefreshRate, value);
+        get => GetProperty<bool>(AutoRefreshRateKey);
+        set => SetProperty(AutoRefreshRateKey, value);
     }
 
     /// <summary>
@@ -96,8 +96,8 @@ public class SettingsManager : ISettingsManager
     /// </summary>
     public bool ForceEnableTvMode
     {
-        get => GetProperty<bool>(_forceEnableTvMode);
-        set => SetProperty(_forceEnableTvMode, value);
+        get => GetProperty<bool>(ForceEnableTvModeKey);
+        set => SetProperty(ForceEnableTvModeKey, value);
     }
 
     private void SetProperty(string propertyName, object value)

--- a/Jellyfin/Core/WebMessage.cs
+++ b/Jellyfin/Core/WebMessage.cs
@@ -7,15 +7,4 @@ namespace Jellyfin.Core;
 /// </summary>
 /// <param name="Type">The defined message type.</param>
 /// <param name="Args">Message contents.</param>
-public record WebMessage(string Type, JsonObject Args)
-{
-    /// <summary>
-    /// Gets the defined message type.
-    /// </summary>
-    public string Type { get; } = Type;
-
-    /// <summary>
-    /// Gets the message contents.
-    /// </summary>
-    public JsonObject Args { get; } = Args;
-}
+public record WebMessage(string Type, JsonObject Args);

--- a/Jellyfin/MainPage.xaml.cs
+++ b/Jellyfin/MainPage.xaml.cs
@@ -23,6 +23,9 @@ public sealed partial class MainPage : Page
     /// <inheritdoc />
     protected override void OnNavigatedFrom(NavigationEventArgs e)
     {
-        ((Content as JellyfinWebView).DataContext as IDisposable).Dispose();
+        if (Content is JellyfinWebView webView && webView.DataContext is IDisposable disposable)
+        {
+            disposable.Dispose();
+        }
     }
 }

--- a/Jellyfin/Resources/winuwp.js
+++ b/Jellyfin/Resources/winuwp.js
@@ -114,6 +114,9 @@
         },
 
         enableFullscreen: function (videoInfo) {
+            // Intentionally empty: HDMI display mode switching is handled by
+            // UwpXboxHdmiSetupPlugin.intercept() which sends the enableFullscreen
+            // message directly via postMessage with video stream metadata.
         },
 
         disableFullscreen: function () {


### PR DESCRIPTION
## Summary
- **Central**: fix copy-pasted XML doc on `MinimumFutureSupportedServerVersion`
- **WebMessage**: remove redundant property re-declarations in positional record
- **MainPage**: replace unsafe cast chain with pattern matching
- **winuwp.js**: document why `enableFullscreen` is intentionally empty
- **SettingsManager**: make settings key strings `const`

## Test plan
- [ ] Verify app launches and navigates to server normally
- [ ] Verify settings persist between app restarts
- [ ] Verify navigating away from MainPage disposes WebView correctly