### PR TITLE
Fix combobox not showing that its focused with a controller.

### DIFF
--- a/Jellyfin/Resources/JellyfinStyleResources.Base.xaml
+++ b/Jellyfin/Resources/JellyfinStyleResources.Base.xaml
@@ -303,6 +303,15 @@
                                     </VisualState.Setters>
                                 </VisualState>
                             </VisualStateGroup>
+                            <VisualStateGroup x:Name="FocusStates">
+                                <VisualState x:Name="Focused">
+                                    <VisualState.Setters>
+                                        <Setter Target="Background.Background" Value="#353535"/>
+                                        <Setter Target="Background.BorderBrush" Value="White"/>
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="Unfocused" />
+                            </VisualStateGroup>
                         </VisualStateManager.VisualStateGroups>
                     </Grid>
                 </ControlTemplate>


### PR DESCRIPTION
Currently the language combobox doesn't look any different when you select it with the controller, but does with a mouse.
This makes sure it looks highlighted with keyboard/controller focus.

Unfocused:
<img width="1322" height="1149" alt="" src="https://github.com/user-attachments/assets/449de18c-6e54-4853-96c8-4847f2e0c5bd" />

Focused:
<img width="1319" height="1123" alt="" src="https://github.com/user-attachments/assets/5b1dc265-ce25-4a35-b7b4-d7be74dcb0d1" />
