### PR TITLE
Fix trailer playback on Xbox with in-app fullscreen player (Fixes #169)

### DIFF
--- a/Jellyfin/Core/FullScreenManager.cs
+++ b/Jellyfin/Core/FullScreenManager.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Jellyfin.Core.Contract;
 using Jellyfin.Utils;
+using Microsoft.Extensions.Logging;
 using Windows.Data.Json;
 using Windows.Graphics.Display.Core;
 using Windows.System.Display;
@@ -21,6 +22,8 @@ public sealed class FullScreenManager : IFullScreenManager
     private readonly ApplicationView _applicationView;
     private readonly Frame _frame;
     private readonly DisplayRequest _displayRequest;
+    private readonly ILogger<FullScreenManager> _logger;
+    private bool _displayRequestActive;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="FullScreenManager"/> class.
@@ -28,11 +31,13 @@ public sealed class FullScreenManager : IFullScreenManager
     /// <param name="applicationView">The <see cref="ApplicationView"/> instance used to manage the application's view state.</param>
     /// <param name="frame">The root frame.</param>
     /// <param name="displayRequest">The display Request.</param>
-    public FullScreenManager(ApplicationView applicationView, Frame frame, DisplayRequest displayRequest)
+    /// <param name="logger">Logger instance.</param>
+    public FullScreenManager(ApplicationView applicationView, Frame frame, DisplayRequest displayRequest, ILogger<FullScreenManager> logger)
     {
         _applicationView = applicationView;
         _frame = frame;
         _displayRequest = displayRequest;
+        _logger = logger;
     }
 
     private async Task SwitchToBestDisplayMode(uint videoWidth, uint videoHeight, double videoFrameRate, HdmiDisplayHdrOption hdmiDisplayHdrOption)
@@ -157,6 +162,44 @@ public sealed class FullScreenManager : IFullScreenManager
         await HdmiDisplayInformation.GetForCurrentView()?.SetDefaultDisplayModeAsync();
     }
 
+    private void RequestDisplayActive()
+    {
+        if (_displayRequestActive)
+        {
+            return;
+        }
+
+        try
+        {
+            _displayRequest.RequestActive();
+            _displayRequestActive = true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "DisplayRequest.RequestActive failed");
+        }
+    }
+
+    private void RequestDisplayRelease()
+    {
+        if (!_displayRequestActive)
+        {
+            return;
+        }
+
+        try
+        {
+            _displayRequest.RequestRelease();
+            _displayRequestActive = false;
+        }
+        catch (Exception ex)
+        {
+            // Keep _displayRequestActive true so we retry release instead of
+            // attempting RequestActive while the lock may still be held.
+            _logger.LogWarning(ex, "DisplayRequest.RequestRelease failed");
+        }
+    }
+
     /// <summary>
     /// Enables Fullscreen.
     /// </summary>
@@ -178,7 +221,7 @@ public sealed class FullScreenManager : IFullScreenManager
                     var hdmiDisplayInformation = HdmiDisplayInformation.GetForCurrentView();
                     var hdmiDisplayHdrOption = GetHdmiDisplayHdrOption(hdmiDisplayInformation, videoRangeType);
                     await SwitchToBestDisplayMode(videoWidth, videoHeight, videoFrameRate, hdmiDisplayHdrOption).ConfigureAwait(false);
-                    _displayRequest.RequestActive();
+                    RequestDisplayActive();
                 }
                 catch (Exception ex)
                 {
@@ -211,6 +254,6 @@ public sealed class FullScreenManager : IFullScreenManager
             _applicationView.ExitFullScreenMode();
         }
 
-        _displayRequest.RequestRelease();
+        RequestDisplayRelease();
     }
 }

--- a/Jellyfin/Resources/winuwp.js
+++ b/Jellyfin/Resources/winuwp.js
@@ -123,7 +123,7 @@
         getPlugins: function () {
             console.debug('getPlugins');
             postMessage('loaded');
-            return ["UwpXboxHdmiSetupPlugin"];
+            return ["UwpXboxHdmiSetupPlugin", "UwpTrailerPlayer"];
         },
 
         selectServer: function () {
@@ -156,6 +156,11 @@ class UwpXboxHdmiSetupPlugin {
             return;
         }
         if ("mediaSourceId" in options) {
+            // Remote trailers have no library media source to probe.
+            if (item.Url && !item.Id) {
+                return;
+            }
+
             const mediaSourceid = options.mediaSourceId;
             var mediaStreams = null;
             var mediaSource = null;
@@ -204,6 +209,534 @@ class UwpXboxHdmiSetupPlugin {
 }
 
 window["UwpXboxHdmiSetupPlugin"] = async () => UwpXboxHdmiSetupPlugin;
+
+/**
+ * In-app fullscreen trailer playback for YouTube, Vimeo, and direct video URLs.
+ */
+class UwpTrailerPlayer {
+    constructor(pluginOptions) {
+        this.name = 'UWP Trailer Player';
+        this.type = 'mediaplayer';
+        this.id = 'uwptrailerplayer';
+        this.priority = -1;
+        this.isLocalPlayer = true;
+        this.PluginOptions = pluginOptions;
+        this._currentSrc = null;
+        this._started = false;
+        this._active = false;
+        this._container = null;
+        this._mediaElement = null;
+        this._ytPlayer = null;
+        this._timeUpdateInterval = null;
+        this.patchPlayTrailers();
+    }
+
+    patchPlayTrailers() {
+        const playbackManager = this.PluginOptions?.playbackManager;
+        if (!playbackManager || playbackManager._uwpTrailerPatchApplied) {
+            return;
+        }
+
+        playbackManager._uwpTrailerPatchApplied = true;
+        const originalPlayTrailers = playbackManager.playTrailers.bind(playbackManager);
+
+        playbackManager.playTrailers = async (item) => {
+            try {
+                if (await this.playTrailersInApp(item)) {
+                    return;
+                }
+            } catch (error) {
+                console.error('In-app trailer playback failed', error);
+                this._active = false;
+                this.PluginOptions?.loading?.hide();
+            }
+
+            return originalPlayTrailers(item);
+        };
+    }
+
+    async playTrailersInApp(item) {
+        const playbackManager = this.PluginOptions?.playbackManager;
+        if (!item || !playbackManager) {
+            return false;
+        }
+
+        const apiClient = this.PluginOptions.ServerConnections.getApiClient(item.ServerId);
+        let trailers = [];
+
+        if (item.LocalTrailerCount) {
+            try {
+                trailers = await apiClient.getLocalTrailers(apiClient.getCurrentUserId(), item.Id) || [];
+            } catch (error) {
+                console.warn('Failed to load local trailers', error);
+            }
+        }
+
+        if (!trailers.length && item.RemoteTrailers?.length) {
+            trailers = item.RemoteTrailers.map((trailer) => ({
+                Name: trailer.Name || (item.Name + ' Trailer'),
+                Url: trailer.Url,
+                MediaType: 'Video',
+                Type: 'Trailer',
+                ServerId: apiClient.serverId()
+            }));
+        }
+
+        if (!trailers.length) {
+            return false;
+        }
+
+        const trailer = trailers[0];
+        const url = trailer.Url || trailer.Path;
+        const trailerType = getTrailerType(url);
+
+        if (trailer.Id && !trailerType) {
+            await playbackManager.play({ items: [trailer], fullscreen: true });
+            return true;
+        }
+
+        if (!trailerType) {
+            return false;
+        }
+
+        this._active = true;
+        await playbackManager.play({ items: [trailer], fullscreen: true });
+        return true;
+    }
+
+    canPlayMediaType(mediaType) {
+        return (mediaType || '').toLowerCase() === 'video';
+    }
+
+    canPlayItem() {
+        return false;
+    }
+
+    canPlayUrl(url) {
+        return this._active && !!getTrailerType(url);
+    }
+
+    play(options) {
+        const url = options?.url;
+        const trailerType = getTrailerType(url);
+        if (!trailerType) {
+            return Promise.reject('ErrorDefault');
+        }
+
+        this._currentSrc = url;
+        this._started = false;
+
+        switch (trailerType) {
+            case 'youtube':
+                return this.playYoutube(url, options);
+            case 'vimeo':
+                return this.playVimeo(url, options);
+            default:
+                return this.playDirectVideo(url, options);
+        }
+    }
+
+    playYoutube(url, options) {
+        const videoId = getYoutubeVideoId(url);
+        if (!videoId) {
+            this.endPlayback();
+            return Promise.reject('ErrorDefault');
+        }
+
+        const head = document.head || document.documentElement;
+        if (head && !document.querySelector('meta[name="referrer"]')) {
+            const meta = document.createElement('meta');
+            meta.name = 'referrer';
+            meta.content = 'strict-origin-when-cross-origin';
+            head.appendChild(meta);
+        }
+
+        return loadYoutubeIframeApi().then(() => new Promise((resolve, reject) => {
+            const fail = (reason) => {
+                this.endPlayback();
+                reject(reason || 'ErrorDefault');
+            };
+
+            try {
+                const container = this.createFullscreenContainer();
+                const hostId = 'uwp-trailer-yt-' + Date.now();
+                container.innerHTML = `<div id="${hostId}" style="width:100%;height:100%;"></div>`;
+
+                this._ytPlayer = new YT.Player(hostId, {
+                    width: '100%',
+                    height: '100%',
+                    videoId: videoId,
+                    host: 'https://www.youtube.com',
+                    playerVars: {
+                        autoplay: 1,
+                        controls: 0,
+                        enablejsapi: 1,
+                        modestbranding: 1,
+                        rel: 0,
+                        fs: 0,
+                        playsinline: 1,
+                        origin: window.location.origin
+                    },
+                    events: {
+                        onReady: (event) => event.target.playVideo(),
+                        onStateChange: (event) => this.onYoutubeStateChange(event, options, resolve),
+                        onError: (event) => {
+                            console.error('YouTube trailer playback failed', event?.data);
+                            fail('ErrorDefault');
+                        }
+                    }
+                });
+            } catch (error) {
+                console.error('Failed to start YouTube trailer playback', error);
+                fail('ErrorDefault');
+            }
+        }));
+    }
+
+    playVimeo(url, options) {
+        const videoId = getVimeoVideoId(url);
+        if (!videoId) {
+            this.endPlayback();
+            return Promise.reject('ErrorDefault');
+        }
+
+        return new Promise((resolve, reject) => {
+            try {
+                const container = this.createFullscreenContainer();
+                const iframe = document.createElement('iframe');
+                iframe.src = `https://player.vimeo.com/video/${videoId}?autoplay=1`;
+                iframe.allow = 'autoplay; fullscreen; encrypted-media; picture-in-picture';
+                iframe.referrerPolicy = 'strict-origin-when-cross-origin';
+                iframe.setAttribute('allowfullscreen', '');
+                iframe.style.cssText = 'width:100%;height:100%;border:0;background:#000;';
+                container.appendChild(iframe);
+                this.onPlaybackStarted(options);
+                resolve();
+            } catch (error) {
+                console.error('Failed to start Vimeo trailer playback', error);
+                this.endPlayback();
+                reject('ErrorDefault');
+            }
+        });
+    }
+
+    playDirectVideo(url, options) {
+        return new Promise((resolve, reject) => {
+            try {
+                const container = this.createFullscreenContainer();
+                const video = document.createElement('video');
+                video.src = url;
+                video.autoplay = true;
+                video.playsInline = true;
+                video.controls = true;
+                video.style.cssText = 'width:100%;height:100%;object-fit:contain;background:#000;';
+                video.addEventListener('playing', () => {
+                    if (!this._started) {
+                        this.onPlaybackStarted(options);
+                        resolve();
+                    }
+                }, { once: true });
+                video.addEventListener('error', () => {
+                    this.endPlayback();
+                    reject('ErrorDefault');
+                }, { once: true });
+                video.addEventListener('ended', () => this.endPlayback());
+                container.appendChild(video);
+                this._mediaElement = video;
+                video.play()?.catch(() => {
+                    this.endPlayback();
+                    reject('ErrorDefault');
+                });
+            } catch (error) {
+                console.error('Failed to start direct trailer playback', error);
+                this.endPlayback();
+                reject('ErrorDefault');
+            }
+        });
+    }
+
+    createFullscreenContainer() {
+        const container = document.createElement('div');
+        container.classList.add('youtubePlayerContainer', 'onTop');
+        // High z-index only while onTop; a permanent value blocks the video OSD on Xbox.
+        container.style.cssText = 'position:fixed;top:0;left:0;width:100%;height:100%;background:#000;z-index:1000;';
+        document.body.insertBefore(container, document.body.firstChild);
+        document.body.classList.add('hide-scroll');
+        this._container = container;
+        return container;
+    }
+
+    onYoutubeStateChange(event, options, resolve) {
+        const events = this.PluginOptions?.events;
+        switch (event.data) {
+            case YT.PlayerState.PLAYING:
+                if (!this._started) {
+                    this.onPlaybackStarted(options);
+                    resolve();
+                } else {
+                    events?.trigger(this, 'unpause');
+                }
+                this.startTimeUpdateInterval();
+                break;
+            case YT.PlayerState.PAUSED:
+                events?.trigger(this, 'pause');
+                break;
+            case YT.PlayerState.ENDED:
+                this.endPlayback();
+                break;
+        }
+    }
+
+    releaseOsdFocus() {
+        if (!this._container) {
+            return;
+        }
+
+        this._container.classList.remove('onTop');
+        this._container.style.zIndex = '';
+        this._container.style.pointerEvents = 'none';
+    }
+
+    startTimeUpdateInterval() {
+        this.clearTimeUpdateInterval();
+        const events = this.PluginOptions?.events;
+        if (!events) {
+            return;
+        }
+
+        this._timeUpdateInterval = setInterval(() => events.trigger(this, 'timeupdate'), 500);
+    }
+
+    clearTimeUpdateInterval() {
+        if (this._timeUpdateInterval) {
+            clearInterval(this._timeUpdateInterval);
+            this._timeUpdateInterval = null;
+        }
+    }
+
+    onPlaybackStarted(options) {
+        this._started = true;
+        this.PluginOptions?.loading?.hide();
+
+        if (options?.fullscreen !== false && this.PluginOptions?.appRouter?.showVideoOsd) {
+            this.PluginOptions.appRouter.showVideoOsd().then(() => {
+                this.releaseOsdFocus();
+            }).catch(() => { });
+        } else {
+            this.releaseOsdFocus();
+        }
+
+        this.PluginOptions?.events?.trigger(this, 'playing');
+    }
+
+    endPlayback() {
+        const src = this._currentSrc;
+        const events = this.PluginOptions?.events;
+
+        this.clearTimeUpdateInterval();
+
+        if (this._ytPlayer) {
+            try {
+                this._ytPlayer.destroy();
+            } catch (error) {
+                console.warn('Failed to destroy YouTube trailer player', error);
+            }
+            this._ytPlayer = null;
+        }
+
+        if (this._mediaElement) {
+            this._mediaElement.pause();
+            this._mediaElement = null;
+        }
+
+        this._container?.remove();
+        this._container = null;
+        document.body.classList.remove('hide-scroll');
+
+        this._currentSrc = null;
+        this._started = false;
+        this._active = false;
+
+        if (events && src) {
+            events.trigger(this, 'stopped', [{ src: src }]);
+        }
+    }
+
+    stop() {
+        if (this._currentSrc) {
+            this.endPlayback();
+        } else {
+            this._active = false;
+        }
+
+        return Promise.resolve();
+    }
+
+    destroy() {
+        this.stop();
+    }
+
+    getDeviceProfile() {
+        return Promise.resolve({});
+    }
+
+    currentSrc() {
+        return this._currentSrc;
+    }
+
+    currentTime(val) {
+        if (this._ytPlayer) {
+            if (val != null) {
+                this._ytPlayer.seekTo(val / 1000, true);
+                return;
+            }
+
+            return this._ytPlayer.getCurrentTime() * 1000;
+        }
+
+        if (this._mediaElement) {
+            if (val != null) {
+                this._mediaElement.currentTime = val / 1000;
+                return;
+            }
+
+            return this._mediaElement.currentTime * 1000;
+        }
+
+        return null;
+    }
+
+    duration() {
+        if (this._ytPlayer) {
+            const duration = this._ytPlayer.getDuration();
+            return duration > 0 ? duration * 1000 : null;
+        }
+
+        const duration = this._mediaElement?.duration;
+        return duration > 0 && duration !== Infinity ? duration * 1000 : null;
+    }
+
+    pause() {
+        this._ytPlayer?.pauseVideo();
+        this._mediaElement?.pause();
+    }
+
+    unpause() {
+        this._ytPlayer?.playVideo();
+        this._mediaElement?.play();
+    }
+
+    paused() {
+        if (this._ytPlayer) {
+            return this._ytPlayer.getPlayerState() === YT.PlayerState.PAUSED;
+        }
+
+        return this._mediaElement ? this._mediaElement.paused : !this._started;
+    }
+
+    volume(val) {
+        if (val != null) {
+            this._ytPlayer?.setVolume(val);
+            return;
+        }
+
+        return this._ytPlayer?.getVolume() ?? 100;
+    }
+
+    setVolume(val) {
+        this.volume(val);
+    }
+
+    getVolume() {
+        return this.volume();
+    }
+
+    setMute(mute) {
+        if (!this._ytPlayer) {
+            return;
+        }
+
+        if (mute) {
+            this._ytPlayer.mute();
+        } else {
+            this._ytPlayer.unMute();
+        }
+    }
+
+    isMuted() {
+        if (this._ytPlayer) {
+            return this._ytPlayer.isMuted();
+        }
+
+        return false;
+    }
+}
+
+function getTrailerType(url) {
+    if (!url || typeof url !== 'string' || !/^https?:\/\//i.test(url)) {
+        return null;
+    }
+
+    const lower = url.toLowerCase();
+    if (lower.includes('youtube.com') || lower.includes('youtu.be') || lower.includes('youtube-nocookie.com')) {
+        return 'youtube';
+    }
+
+    if (lower.includes('vimeo.com')) {
+        return 'vimeo';
+    }
+
+    if (/\.(mp4|webm|mkv|mov|m4v|avi|mpg|mpeg)(\?|#|$)/i.test(url)
+        || /\/(videos|stream|trailer)/i.test(url)) {
+        return 'direct';
+    }
+
+    return null;
+}
+
+function loadYoutubeIframeApi() {
+    return new Promise((resolve) => {
+        if (window.YT?.Player) {
+            resolve();
+            return;
+        }
+
+        const previousReady = window.onYouTubeIframeAPIReady;
+        window.onYouTubeIframeAPIReady = function () {
+            previousReady?.();
+            resolve();
+        };
+
+        if (!document.querySelector('script[src*="youtube.com/iframe_api"]')) {
+            const tag = document.createElement('script');
+            tag.src = 'https://www.youtube.com/iframe_api';
+            (document.head || document.documentElement).appendChild(tag);
+        }
+    });
+}
+
+function getYoutubeVideoId(url) {
+    try {
+        const parsed = new URL(url);
+        if (parsed.hostname.includes('youtu.be')) {
+            return parsed.pathname.replace(/^\//, '').split('/')[0] || null;
+        }
+
+        return parsed.searchParams.get('v')
+            || parsed.pathname.match(/\/embed\/([^/?]+)/i)?.[1]
+            || null;
+    } catch (error) {
+        console.warn('Failed to parse YouTube trailer URL', error);
+        return null;
+    }
+}
+
+function getVimeoVideoId(url) {
+    const match = url.match(/vimeo\.com\/(?:channels\/[^/]+\/|groups\/[^/]+\/videos\/|video\/)?(\d+)/i);
+    return match ? match[1] : null;
+}
+
+window["UwpTrailerPlayer"] = async () => UwpTrailerPlayer;
 
 if (!window.consoleXboxOverride)
 {


### PR DESCRIPTION
## Summary

Fixes #169

Remote trailers (YouTube, Vimeo, direct URLs) fail silently on Xbox because jellyfin-web's in-webview iframe player cannot load them reliably in WebView2. Pressing **Play Trailer** appears to do nothing.

This change adds an in-app fullscreen trailer player scoped to trailer playback only:

- **`winuwp.js`**: Adds `UwpTrailerPlayer` mediaplayer with a `playTrailers` intercept; plays YouTube (IFrame API + referrer policy for Error 153), Vimeo, and direct video URLs in a fullscreen overlay
- **`UwpXboxHdmiSetupPlugin`**: Skips HDMI pre-play setup for remote URL-only trailer items (`item.Url && !item.Id`)
- **`FullScreenManager.cs`**: Guards `DisplayRequest` release so exiting trailer playback does not crash when display was never activated

Local server-stored trailers continue through normal Jellyfin server playback. No external browser or `openUrl` shell changes.

## Test plan

- [x] Rebuild and deploy to Xbox Series X/S
- [x] Fully restart the Jellyfin app
- [x] Open a movie/show with a remote YouTube trailer and press **Play Trailer**
- [x] Confirm trailer plays in-app fullscreen (not external browser)
- [x] Confirm app does not crash on exit after trailer playback