### PR TITLE
Fix HLS transcode playback for AC3 content on Xbox

### DIFF
--- a/Jellyfin/Resources/winuwp.js
+++ b/Jellyfin/Resources/winuwp.js
@@ -97,8 +97,12 @@
                 if (supportsDolbyVision != null) {
                     options.supportsDolbyVision = supportsDolbyVision;
                 }
-                if (xboxSeries) {
-                    options.maxVideoWidth = 3840;
+                if (xbox) {
+                    // MSE cannot decode AC3 in HLS fMP4 despite WebView2 reporting support.
+                    options.disableHlsVideoAudioCodecs = ['ac3', 'eac3'];
+                    if (xboxSeries) {
+                        options.maxVideoWidth = 3840;
+                    }
                 }
                 return profileBuilder(options);
             },


### PR DESCRIPTION
## Summary

Fixes #180 #177 

WebView2 on Xbox reports AC3 and E-AC3 as supported for HLS fMP4, so Jellyfin keeps AC3 in transcoded streams. The browser MSE pipeline cannot actually decode AC3 in fMP4 segments, which causes \ufferAppendError\, \FATAL_HLS_ERROR\, and playback failure for common MKV content (H.264 + AC3).

## Fix

In the Xbox shell device profile, disable AC3/E-AC3 for HLS via jellyfin-web's existing \disableHlsVideoAudioCodecs\ option. The server then transcodes audio to AAC, which plays correctly.

## Testing

- Confirmed on Xbox Series X against Jellyfin 10.11.11
- Repro content: *Under the Dome* S01E06 (MKV, H.264 + AC3 5.1) — previously failed, now plays
- Transcode URL changes from \AudioCodec=ac3\ to \AudioCodec=aac\

## Scope

Single change in \Jellyfin/Resources/winuwp.js\ (\getDeviceProfile\). No impact on trailer playback, music, or non-Xbox platforms.

fixes #180
fixes #177